### PR TITLE
Added Scala IDE update sites for 2.10.0-RC3

### DIFF
--- a/hand-written.md
+++ b/hand-written.md
@@ -46,4 +46,9 @@ This is the third RC of Scala 2.10.0 release. This release comes with a few new 
 * Addition of `???` and `NotImplementedError`
 * Addition of `IsTraversableOnce` + `IsTraversableLike` type classes for extension methods
 
+### Scala IDE for Eclipse
 
+If you are an Eclipse user, you can install the Scala IDE with Scala 2.10.0-RC3 through one of the following update-sites:
+
+* Eclipse 3.7 (Indigo) - [http://download.scala-ide.org/sdk/e37/scala210/dev/site/](http://download.scala-ide.org/sdk/e37/scala210/dev/site/)
+* Eclipse 3.8/4.2 (Juno) - [http://download.scala-ide.org/sdk/e38/scala210/dev/site/](http://download.scala-ide.org/sdk/e38/scala210/dev/site/)


### PR DESCRIPTION
Here comes the update sites for installing the Scala IDE with 2.10.0-RC3.

Please, let me know what you think. One thing that I feel is missing is a link to the scala-ide website. Or, maybe even better, to get Getting Started sceencast, so that users new to Eclipse can underdstand how to use the provided update sites. What do you think, should I add a link?
