### PR TITLE
html doesn't infer semicolons like scala does

### DIFF
--- a/src/main/scala/GitInfo.scala
+++ b/src/main/scala/GitInfo.scala
@@ -52,7 +52,7 @@ class GitInfo(gitDir: java.io.File, val previousTag: String, val currentTag: Str
   private def commitShaLink(sha: String) = 
     s"""<a href="https://github.com/scala/scala/commit/${sha}">${sha}</a>"""
 
-  private def blankLine(): String = "<p>&nbsp</p>"
+  private def blankLine(): String = "<p>&nbsp;</p>"
   private def header4(msg: String): String = s"<h4>$msg</h4>"
 
   def renderCommitterList: String = {


### PR DESCRIPTION
REVIEW THIS, @jsuereth 

found while htmltidy'ing today's release notes
yes -- i'm that obsessive
