### PR TITLE
Add links to deb and rpm files to the download page

### DIFF
--- a/src/main/scala/MakeDownloadPage.scala
+++ b/src/main/scala/MakeDownloadPage.scala
@@ -55,6 +55,8 @@ resources: [
   ${resourceArchive("-main-unixsys", "scala",               "tgz",  "Max OS X, Unix, Cygwin"   )}
   ${resourceArchive("-main-windows", "scala",               "msi",  "Windows (msi installer)"  )},
   ${resourceArchive(defaultClass,    "scala",               "zip",  "Windows"                  )},
+  ${resourceArchive(defaultClass,    "scala",               "deb",  "Debian"                   )},
+  ${resourceArchive(defaultClass,    "scala",               "rpm",  "RPM Package"              )},
   ${resourceArchive(defaultClass,    "scala-docs",          "txz",  "API docs"                 )},
   ${resourceArchive(defaultClass,    "scala-docs",          "zip",  "API docs"                 )},
   ${resource       (defaultClass,    s"scala-sources-$version.zip", "sources", ghSourceUrl, ghSourceUrl)},


### PR DESCRIPTION
Hi,

I found that [the Scala 2.10.3 download page](http://www.scala-lang.org/download/2.10.3.html) does not contain links to [deb](http://www.scala-lang.org/files/archive/scala-2.10.3.deb) and [rpm](http://www.scala-lang.org/files/archive/scala-2.10.3.rpm) files which exist themselves.
I guess this PR fixes that!

See the below for the issue relates to this PR:
https://issues.scala-lang.org/browse/SI-7890

Thanks,
Yusuke Kuoka
