### PR TITLE
Add .deb and .rpm to the generated download page.

### DIFF
--- a/src/main/scala/MakeDownloadPage.scala
+++ b/src/main/scala/MakeDownloadPage.scala
@@ -55,6 +55,8 @@ resources: [
   ${resourceArchive("-main-unixsys", "scala",               "tgz",  "Max OS X, Unix, Cygwin"   )}
   ${resourceArchive("-main-windows", "scala",               "msi",  "Windows (msi installer)"  )},
   ${resourceArchive(defaultClass,    "scala",               "zip",  "Windows"                  )},
+  ${resourceArchive(defaultClass,    "scala",               "deb",  "Debian"                   )},
+  ${resourceArchive(defaultClass,    "scala",               "rpm",  "RPM package"              )},
   ${resourceArchive(defaultClass,    "scala-docs",          "txz",  "API docs"                 )},
   ${resourceArchive(defaultClass,    "scala-docs",          "zip",  "API docs"                 )},
   ${resource       (defaultClass,    s"scala-sources-$version.zip", "sources", ghSourceUrl, ghSourceUrl)},

--- a/src/main/scala/MakeDownloadPage.scala
+++ b/src/main/scala/MakeDownloadPage.scala
@@ -52,7 +52,7 @@ show_resources: "true"
 permalink: /download/$version.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ${resourceArchive("-main-unixsys", "scala",               "tgz",  "Max OS X, Unix, Cygwin"   )}
+  ${resourceArchive("-main-unixsys", "scala",               "tgz",  "Max OS X, Unix, Cygwin"   )},
   ${resourceArchive("-main-windows", "scala",               "msi",  "Windows (msi installer)"  )},
   ${resourceArchive(defaultClass,    "scala",               "zip",  "Windows"                  )},
   ${resourceArchive(defaultClass,    "scala",               "deb",  "Debian"                   )},


### PR DESCRIPTION
Which were meant to be there all along.

Review by @gkossakowski
