### PR TITLE
Encapsulate release notes gen, 2.10.4-RC1 data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "scala-release-note-generator"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.10.3"
 
 libraryDependencies += "org.pegdown" % "pegdown" % "1.2.0"
 

--- a/hand-written.md
+++ b/hand-written.md
@@ -1,20 +1,25 @@
-We are very happy to announce the final release of Scala 2.10.3! <!-- If no serious blocking issues are found this will become the final 2.10.3 version. -->
+<!--
+Things to update:
+ - create new jira filters for fixed bugs, known issues,
+ - link to closed milestone (after clearing milestone of un-merged PRs with https://github.com/adriaanm/binfu/blob/master/hubfu.sh#L29)
+ - versions to search-replace: 2.10.4-RC1 (current release), 2.10.3 (previous release)
+-->
+We are very happy to announce the first release candidate of Scala 2.10.4!
+If no serious blocking issues are found this will become the final 2.10.4 version.
 
 <!-- Substitute both version numbers here! -->
-The release is available for download from [scala-lang.org](http://scala-lang.org/download/2.10.3.html) or from [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.10.3%22).
+The release is available for download from [scala-lang.org](http://scala-lang.org/download/2.10.4-RC1.html) or from [Maven Central](http://search.maven.org/#search|ga|1|g:"org.scala-lang" AND v:"2.10.4-RC1").
 
-The Scala team and contributors [fixed 50 issues since 2.10.2](https://issues.scala-lang.org/secure/IssueNavigator.jspa?mode=hide&requestId=12215)!
+The Scala team and contributors [fixed 23 issues since 2.10.3](https://issues.scala-lang.org/issues/?filter=12308)!
 
 In total, 
-[63 RC1 pull requests](https://github.com/scala/scala/issues?milestone=17&state=closed), 
-[19 RC2 pull requests](https://github.com/scala/scala/issues?milestone=23&state=closed) and
-[2 RC3 pull requests](https://github.com/scala/scala/issues?milestone=24&state=closed)
-were opened on [GitHub](https://github.com/scala/scala) of which 72 were merged after having been [tested](https://github.com/typesafehub/ghpullrequest-validator) and reviewed.
+[39 RC1 pull requests](https://github.com/scala/scala/issues?milestone=22&state=closed)
+were merged on [GitHub](https://github.com/scala/scala).
 
 <!--break-->
 
 ### Known Issues
-Before reporting a bug, please have a look at these [known issues](https://issues.scala-lang.org/secure/IssueNavigator.jspa?mode=hide&requestId=12216).
+Before reporting a bug, please have a look at these [known issues](https://issues.scala-lang.org/issues/?filter=12309).
 
 ### Scala IDE for Eclipse
 The Scala IDE with this release built right in is available through the following update-site:
@@ -24,7 +29,7 @@ The Scala IDE with this release built right in is available through the followin
 Have a look at the [getting started guide](http://scala-ide.org/docs/user/gettingstarted.html) for more info.
 
 ### New features in the 2.10 series
-Since 2.10.3 is strictly a bug-fix release, here's an overview of the most prominent new features and improvements as introduced in 2.10.0:
+Since 2.10.4 is strictly a bug-fix release, here's an overview of the most prominent new features and improvements as introduced in 2.10.0:
 
 * Value Classes
     * A class may now extend `AnyVal` to make it behave like a struct type (restrictions apply).

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.1

--- a/src/main/scala/MakeDownloadPage.scala
+++ b/src/main/scala/MakeDownloadPage.scala
@@ -55,6 +55,8 @@ resources: [
   ${resourceArchive("-main-unixsys", "scala",               "tgz",  "Max OS X, Unix, Cygwin"   )}
   ${resourceArchive("-main-windows", "scala",               "msi",  "Windows (msi installer)"  )},
   ${resourceArchive(defaultClass,    "scala",               "zip",  "Windows"                  )},
+  ${resourceArchive(defaultClass,    "scala",               "deb",  "Debian"                   )},
+  ${resourceArchive(defaultClass,    "scala",               "rpm",  "RPM package"              )},
   ${resourceArchive(defaultClass,    "scala-docs",          "txz",  "API docs"                 )},
   ${resourceArchive(defaultClass,    "scala-docs",          "zip",  "API docs"                 )},
   ${resource       (defaultClass,    s"scala-sources-$version.zip", "sources", ghSourceUrl, ghSourceUrl)},

--- a/src/main/scala/MakeDownloadPage.scala
+++ b/src/main/scala/MakeDownloadPage.scala
@@ -1,43 +1,71 @@
 import java.util.Date
 import java.text._
+import scala.concurrent._
+import scala.concurrent.duration._
+import ExecutionContext.Implicits.global
 
 class MakeDownloadPage(version: String, releaseDate: Date = new Date()) {
   def write() = {
     require(!version.startsWith("v"), "version should *not* start with 'v'")
     val fileName = s"${format("yyyy-MM-dd")}-$version.md"
     IO.write(new java.io.File(fileName), page)
-    println("generated " + fileName)
+    println("cp " + fileName + " ../scala-lang/download/_posts/")
+    println("# to prepare your scala-lang PR")
   }
 
-  def humanSize(url: String) = {
+  // get size of `url` without actually downloading it
+  def humanSize(url: String): Future[String] = future {
     import scala.sys.process._
     println(url)
-    val tmpFile = java.io.File.createTempFile("download", ".tmp")
-    val res = s"curl --fail --silent --output ${tmpFile.getAbsolutePath} $url".!
-    val dfOutput = s"du -h ${tmpFile.getAbsolutePath}".!!
-    val output = dfOutput.trim.split("\t").head
-    if (output == "0B") {
-      println(s"warning: could not fetch $url")
-      ""
-    } else output
+    scala.util.Try {
+      val responseHeader = Process(s"curl --silent -D - -X HEAD $url").lines
+      val contentLength = responseHeader.find(_.startsWith("Content-Length"))
+      val bytes = contentLength.map(_.split(":",2)(1).trim.toInt)
+      bytes map (b => (responseHeader.head, b))
+    }.toOption.flatten.map { case (status, bytes) => (status, bytes match {
+        case meh if meh < 1024                        => ""
+        case kilo if kilo < 1024*1024                 => f"${bytes.toDouble/1024}%.0fK"
+        case big                                      => f"${bytes.toDouble/(1024*1024)}%.2fM"
+      })} match {
+      case Some((status, humanSize)) if status.contains("200 OK") || status.contains("302 Found") =>
+        humanSize
+      case _ =>
+        println(s"warning: could not fetch $url")
+        ""
+    }
   }
 
-  def resourceArchive(cls: String, name: String, ext: String, desc: String) = {
+  def resourceArchive(cls: String, name: String, ext: String, desc: String): Future[String] = {
     val fileName = s"$name-$version.$ext"
     val relUrl = s"/files/archive/$fileName"
     val fullUrl = s"http://www.scala-lang.org$relUrl"
     resource(cls, fileName, desc, relUrl, fullUrl)
   }
 
-  def resource(cls: String, fileName: String, desc: String, relUrl: String, fullUrl: String) = {
-    s"""[$cls, "$fileName", "$relUrl", "$desc", "${humanSize(fullUrl)}"]"""
+  def resource(cls: String, fileName: String, desc: String, relUrl: String, fullUrl: String): Future[String] = {
+    humanSize(fullUrl) map (size => s"""[$cls, "$fileName", "$relUrl", "$desc", "$size"]""")
   }
 
-  def defaultClass = "-non-main-sys"
+  def defaultClass = """"-non-main-sys""""
+  def unixClass    = """"-main-unixsys""""
+  def windowsClass = """"-main-windows""""
 
   def format(fmt: String) = new SimpleDateFormat(fmt).format(releaseDate)
 
   def ghSourceUrl = s"https://github.com/scala/scala/archive/v$version.tar.gz"
+
+  def resources: String = Await.result(
+  Future.sequence(Seq(
+    resourceArchive(unixClass, "scala",               "tgz",  "Max OS X, Unix, Cygwin"   ),
+    resourceArchive(windowsClass, "scala",               "msi",  "Windows (msi installer)"  ),
+    resourceArchive(defaultClass,    "scala",               "zip",  "Windows"                  ),
+    resourceArchive(defaultClass,    "scala",               "deb",  "Debian"                   ),
+    resourceArchive(defaultClass,    "scala",               "rpm",  "RPM package"              ),
+    resourceArchive(defaultClass,    "scala-docs",          "txz",  "API docs"                 ),
+    resourceArchive(defaultClass,    "scala-docs",          "zip",  "API docs"                 ),
+    resource       (defaultClass,    s"scala-sources-$version.zip", "sources", ghSourceUrl, ghSourceUrl),
+    resourceArchive(defaultClass,    "scala-tool-support",  "tgz",  "Scala Tool Support (tgz)"),
+    resourceArchive(defaultClass,    "scala-tool-support",  "zip",  "Scala Tool Support (zip)"))).map(_.mkString(",\n  ")), 20 seconds)
 
   def page: String = {
 
@@ -52,16 +80,7 @@ show_resources: "true"
 permalink: /download/$version.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ${resourceArchive("-main-unixsys", "scala",               "tgz",  "Max OS X, Unix, Cygwin"   )}
-  ${resourceArchive("-main-windows", "scala",               "msi",  "Windows (msi installer)"  )},
-  ${resourceArchive(defaultClass,    "scala",               "zip",  "Windows"                  )},
-  ${resourceArchive(defaultClass,    "scala",               "deb",  "Debian"                   )},
-  ${resourceArchive(defaultClass,    "scala",               "rpm",  "RPM package"              )},
-  ${resourceArchive(defaultClass,    "scala-docs",          "txz",  "API docs"                 )},
-  ${resourceArchive(defaultClass,    "scala-docs",          "zip",  "API docs"                 )},
-  ${resource       (defaultClass,    s"scala-sources-$version.zip", "sources", ghSourceUrl, ghSourceUrl)},
-  ${resourceArchive(defaultClass,    "scala-tool-support",  "tgz",  "Scala Tool Support (tgz)")},
-  ${resourceArchive(defaultClass,    "scala-tool-support",  "zip",  "Scala Tool Support (zip)")}
+  $resources
 ]
 ---
 

--- a/src/main/scala/TargetLanguage.scala
+++ b/src/main/scala/TargetLanguage.scala
@@ -7,8 +7,10 @@ sealed trait TargetLanguage {
   def tableHeader(firstColumn: String, secondColumn: String, thirdColumn: String): String
   def tableRow(firstColumn: String, secondColumn: String, thirdColumn: String): String
   def tableEnd: String
+  def ext: String
 }
 case object MarkDown extends TargetLanguage {
+  val ext = "md"
   def createHyperLink(link: String, content: String): String =
     s"[$content]($link)"
   def blankLine(): String = "\n"
@@ -38,6 +40,7 @@ $firstColumn | $secondColumn | $thirdColumn
   }
 }
 case object Html extends TargetLanguage {
+  val ext = "html"
   def createHyperLink(link: String, content: String): String =
     s"""<a href="$link">$content</a>"""
   def blankLine(): String = "<p>&nbsp;</p>"


### PR DESCRIPTION
It also doesn't actually download the files anymore,
just parses the Content-Length part of the header (asynchronously).

For example:

```
sbt -Dfile.encoding=UTF-8 console
scala> MakeReleaseNotes.genPR("2.10.3", "2.10.4-RC1", "2013/12/20")
```

The output is copy/pasteable in bash to create your scala/scala-lang PR.

/cc @retronym, @gkossakowski
