### PR TITLE
akka-actor 2.3.0-RC4 and final differ.

### DIFF
--- a/hand-written.md
+++ b/hand-written.md
@@ -50,7 +50,7 @@ The following Scala projects have already been released against 2.11.0-RC1! We'd
     "org.scalaz"        %% "scalaz-core"        % "7.0.6"
     "com.nocandysw"     %% "platform-executing" % "0.5.0"
 
-NOTE: RC1 ships with akka-actor 2.3.0-RC4 (the final is out now, but wasn't yet available when RC1 was cut). The next Scala 2.11 RC will ship with (the identical) akka-actor 2.3.0 final.
+NOTE: RC1 ships with akka-actor 2.3.0-RC4 (the final is out now, but wasn't yet available when RC1 was cut). The next Scala 2.11 RC will ship with akka-actor 2.3.0 final.
 
 ### Cross-building with sbt 0.13
 When cross-building between Scala versions, you often need to vary the versions of your dependencies. In particular, the new scala modules (such as scala-xml) are no longer included in scala-library, so you'll have to add an explicit dependency on it to use Scala's xml support.


### PR DESCRIPTION
The release notes state that akka-actor 2.3.0 will be identical to RC4, but [the news](http://akka.io/news/2014/03/05/akka-2.3.0-released.html) lists differences, as well akka-actor-specific changes in [the comparison between the tags](https://github.com/akka/akka/compare/v2.3.0-RC4...v2.3.0).
