### PR TITLE
Add hooks for non-scala projects to use the git-info structure we have.

### DIFF
--- a/src/main/scala/IssueDetector.scala
+++ b/src/main/scala/IssueDetector.scala
@@ -1,0 +1,50 @@
+/**
+ * Trait used to detect + create links to issue comments
+ * in git commits.
+ */
+trait IssueDetector {
+  def isFixCommit(commit:  Commit): Boolean
+  def issueLink(commit: Commit)(implicit targetLanguage: TargetLanguage): String
+}
+
+/**
+ * Detector for issue tracking in scala commit messages.
+ */
+object ScalaIssueDetector extends IssueDetector {
+  private val siPattern = java.util.regex.Pattern.compile("(SI-[0-9]+)")
+  private def hasFixins(msg: String): Boolean = (
+    (msg contains "SI-") /*&& ((msg.toLowerCase contains "fix") || (msg.toLowerCase contains "close"))*/
+  )
+  private def fixLinks(commit: Commit)(implicit targetLanguage: TargetLanguage): String = {
+    val searchString = commit.body + commit.header
+    val m = siPattern matcher searchString
+    val issues = new collection.mutable.ArrayBuffer[String]
+    while (m.find()) {
+      issues += (m group 1)
+    }
+    issues map (si => targetLanguage.createHyperLink(s"https://issues.scala-lang.org/browse/$si", si)) mkString ", "
+  }
+  
+  def isFixCommit(commit:  Commit): Boolean = 
+    hasFixins(commit.body + commit.header)
+  def issueLink(commit: Commit)(implicit targetLanguage: TargetLanguage): String =  
+    fixLinks(commit)
+}
+
+
+/**
+ * Detector for issue tracking in canonical github projects.
+ */
+case class GithubIssueDetector(project: GithubProject) extends IssueDetector {
+  import GithubIssueDetector.IssueNum
+  def isFixCommit(commit:  Commit): Boolean = 
+    (commit.body + commit.header).toLowerCase contains "fix"  // TODO && contains # ?
+  def issueLink(commit: Commit)(implicit targetLanguage: TargetLanguage): String ={
+  	(commit.body + commit.header).split("[\r\n]+").collect {
+  		case IssueNum(num) => targetLanguage.createHyperLink(s"https://github.com/${project.user}/${project.project}/issues/${num}", num)
+  	} mkString " "
+  }
+}
+object GithubIssueDetector {
+  val IssueNum = new scala.util.matching.Regex(".*\\#([0-9]+).*")
+}

--- a/src/main/scala/NativePackagerReleaseNotes.scala
+++ b/src/main/scala/NativePackagerReleaseNotes.scala
@@ -1,0 +1,58 @@
+import java.io.File
+
+
+
+object BasicGithubReleeaseNotes {
+  val GhProjectString = new util.matching.Regex("([^/]+)/(.+)")
+
+  case class Config(project: GithubProject, previousTag: String, nextTag: String, location: File)
+  
+  def main(arg: Array[String]): Unit = {
+    def usage(): Nothing = {
+      System.err.println("Usage:  BasicGithubReleeaseNotes  options*")
+      System.err.println(" ")
+      System.err.println(" * -gh  <user/project>   Github project to use")
+      System.err.println(" * -p  <tag>             Previous tag to compare against")
+      System.err.println(" * -n  <tag>             Release tag to generate notes for")
+      System.err.println(" * -l  <directory>       Location of the project.")
+      System.exit(1)
+      sys.error("no return from usage")
+    }
+    // TODO - Something better than junk for reading.
+    def readArgs(
+        remaining: List[String] = arg.toList, 
+        project: Option[GithubProject] = None, 
+        previousTag: Option[String] = None, 
+        nextTag: Option[String] = None,
+        location: Option[File] = Some(new File("."))
+    ): Config =
+      remaining match {
+        case "-h" :: rest => usage()
+        case "-gh" :: GhProjectString(user, project) :: rest => readArgs(rest, Some(GithubProject(user, project)), previousTag, nextTag, location)
+        case GhProjectString(user, project) :: rest => readArgs(rest, Some(GithubProject(user, project)), previousTag, nextTag, location)
+        case "-p" :: prev :: rest => readArgs(rest, project, Some(prev), nextTag, location)
+        case "-n" :: next :: rest => readArgs(rest, project, previousTag, Some(next), location)
+        case "-l" :: location :: rest => readArgs(rest, project, previousTag, nextTag, Some(new File(location)))
+        case unknown :: rest =>
+          System.err.println(s"Unknown option: ${unknown}")
+          usage()
+        case Nil =>
+          // Default, we check to see if we have everyting:
+          (for {
+            pj <- project
+            pt <- previousTag
+            nt <- nextTag
+            l  <- location
+          } yield Config(pj, pt, nt, l)) match {
+            case Some(config) => config
+            case _ => usage()
+          }
+      }
+    val Config(project, prev, next, loc) = readArgs()
+    implicit val language = MarkDown
+    val info = new GitInfo(loc, prev, next, project, GithubIssueDetector(project))
+    println(info.renderFixedIssues)
+    //println(info.renderCommitList)
+    println(info.renderCommitterList)
+  }
+}


### PR DESCRIPTION
particularly EVERY sbt-related project which uses the default github stuffs,
including  main method that will generate basic release notes for sbt projects.

Review @adriaanm or @retronym or @gkossakowski
