### PR TITLE
Strip internal comments from generated markdown.

### DIFF
--- a/hand-written.md
+++ b/hand-written.md
@@ -1,4 +1,6 @@
-<!-- comment at the top because it breaks the markdown parser when it's where we'd actually like it...
+<!---
+NOTE: Our generator now strips triple-dash comments form the generated markdown.
+      These have been problematic for jekyll.
 Things to update:
 - replace 2.11.0-RCX-1 by previous version,
 - replace 2.11.0-RCX by actual version,

--- a/src/main/scala/MakeReleaseNotes.scala
+++ b/src/main/scala/MakeReleaseNotes.scala
@@ -59,6 +59,9 @@ object MakeReleaseNotes {
     parser markdownToHtml content
   }
 
+  private def stripTripleDashedHtmlComments(s: String): String =
+    s.replaceAll("""(?ims)<!---.*?-->""", "")
+
   private def makeReleaseNotes(scalaDir: java.io.File, previousTag: String, currentTag: String)(implicit targetLanguage: TargetLanguage): String = {
     def rawHandWrittenNotes(file: java.io.File = new java.io.File(s"hand-written.md")): String = {
       val lines: List[String] = if (file.exists) {
@@ -68,8 +71,9 @@ object MakeReleaseNotes {
       // if you don't have the next line, sub-bullets would be screwed!
       // please take this case into account and comment out 2 next lines and uncomment the line after!
       val newLines = lines.map(x => if (x.startsWith("    *")) "\n" + x.stripPrefix("  ") else x)
-      newLines.mkString("\n")
-      //      lines.mkString("\n")
+      val bulletFixed = newLines.mkString("\n")
+      val commentsStripped = stripTripleDashedHtmlComments(bulletFixed)
+      commentsStripped
     }
     val info = new GitInfo(scalaDir, previousTag, currentTag)
     // val communityProjects = CommunityProjects.loadHtmlFromFile()


### PR DESCRIPTION
```
<!--- triple dashed comment is stripped -->
<!-- double dashed comment is passed through -->
```

I based this on the loose idea in:

   https://groups.google.com/forum/#!topic/pandoc-discuss/FnTRTIhCEi4

This seeks to avoid a problem with layout of the home page.
After publishing the 2.11.0 announcement, the presence of a
multiline HTML comment at the start of the _previous_ news
announcement was enough to result in a wonky layout!
