### PR TITLE
stateless-future have been prepared for 2.11.0

### DIFF
--- a/hand-written.md
+++ b/hand-written.md
@@ -39,6 +39,7 @@ The Scala IDE with this release built in is [available from this update site](ht
 ### Available projects
 The following Scala projects have already been released against 2.11.0! We'd love to include yours in this list as soon as it's available -- please submit a PR to update [these release notes](https://github.com/scala/make-release-notes/blob/master/hand-written.md).
 
+    "com.qifun"              %% "stateless-future"   % "0.1.1"
     "org.scalacheck"         %% "scalacheck"         % "1.11.3"
     "com.typesafe.akka"      %% "akka-actor"         % "2.3.2"
     "org.scala-lang.modules" %% "scala-async"        % "0.9.1"


### PR DESCRIPTION
The project URL:
https://github.com/Atry/stateless-future

The repository URL:
http://central.maven.org/maven2/com/qifun/stateless-future_2.11/0.1.1/
