### PR TITLE
scopt 3.2.0 for Scala 2.11.0

### DIFF
--- a/hand-written.md
+++ b/hand-written.md
@@ -48,6 +48,7 @@ The following Scala projects have already been released against 2.11.0! We'd lov
     "com.chuusai"            %% "shapeless"          % "1.2.4"
     "com.chuusai"            %% "shapeless"          % "2.0.0"
     "org.nalloc"             %% "optional"           % "0.1.0"
+    "com.github.scopt"       %% "scopt"              % "3.2.0"
 
 The following projects were released against 2.11.0-RC4, with an 2.11 build hopefully following soon:
 
@@ -60,7 +61,6 @@ The following projects were released against 2.11.0-RC4, with an 2.11 build hope
     "com.propensive"         %% "rapture-json"       % "0.9.1"
     "com.propensive"         %% "rapture-io"         % "0.9.1"
     "org.scalafx"            %% "scalafx"            % "1.0.0-R8"
-    "com.github.scopt"       %% "scopt"              % "3.2.0"
     "com.nocandysw"          %% "platform-executing" % "0.5.0"
     "io.argonaut"            %% "argonaut"           % "6.0.3"
     "com.clarifi"            %% "f0"                 % "1.1.1"


### PR DESCRIPTION
scopt 3.2.0 is published to Sonatype - https://oss.sonatype.org/content/repositories/releases/com/github/scopt/scopt_2.11/3.2.0/
