### PR TITLE
commons-continuations and memcontinuationed for Scala 2.11

### DIFF
--- a/hand-written.md
+++ b/hand-written.md
@@ -99,6 +99,8 @@ The following Scala projects have already been released against 2.11.0! We'd lov
     "com.nocandysw"                    %% "platform-executing"        % "0.5.0"
     "com.qifun"                        %% "stateless-future"          % "0.1.1"
     "com.github.scopt"                 %% "scopt"                     % "3.2.0"
+    "com.dongxiguo"                    %% "commons-continuations"     % "0.2.2"
+    "com.dongxiguo"                    %% "memcontinuationed"         % "0.3.2"
     "com.dongxiguo"                    %% "fastring"                  % "0.2.4"
     "com.dongxiguo"                    %% "zero-log"                  % "0.3.5"
     "com.github.seratch"               %% "ltsv4s"                    % "1.0.0"


### PR DESCRIPTION
The project URL:
https://github.com/Atry/commons-continuations
https://github.com/Atry/memcontinuationed

The repository URL:
http://central.maven.org/maven2/com/dongxiguo/commons-continuations_2.11/0.2.2/
http://central.maven.org/maven2/com/dongxiguo/memcontinuationed_2.11/0.3.2/
