### PR TITLE
2.12.0 m1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 name := "scala-release-note-generator"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.11.5"
 
 libraryDependencies += "org.pegdown" % "pegdown" % "1.2.0"
-
 libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.1"
+libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.3"
 
 {
   require(sys.props("file.encoding") == "UTF-8", "Please rerun with -Dfile.encoding=UTF-8")

--- a/hand-written.md
+++ b/hand-written.md
@@ -1,22 +1,18 @@
-We are very pleased to announce the release of Scala 2.11.1!
+We are very pleased to announce the release of Scala 2.11.2!
 
 * Get started with the [Hello Scala 2.11 template](https://typesafe.com/activator/template/hello-scala-2_11) in [Typesafe Activator](https://typesafe.com/platform/getstarted)
-* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.1.html)
-* Obtain it via [Maven Central](http://search.maven.org/?search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.1%22#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.1%22)
+* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.2.html)
+* Obtain it via [Maven Central](http://search.maven.org/?search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.2%22#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.2%22)
 
-This release contains [an important fix](https://github.com/scala/scala/pull/3711) for serialization, which was broken in Scala 2.11.0 ([SI-8549](https://issues.scala-lang.org/browse/SI-8549)).
-The fix necessarily breaks serialization compatibility between 2.11.0 and 2.11.1 (this is separate from binary compatibility, which is maintained).
+Scala 2.11.2 is a bugfix release that is binary compatible with previous releases in the Scala 2.11 series. The changes include:
 
-Users of distributed systems that rely on serialization to exchange objects (such as akka) should upgrade to Scala 2.11.1 (and akka 2.3.3) immediately.
-We also strongly recommend that libraries that themselves declare classes with [@SerialVersionUID](http://www.scala-lang.org/api/2.11.1/index.html#scala.SerialVersionUID) annotations release a new version and ask their Scala 2.11 users to upgrade.
+* Several [issues in the collections library](https://issues.scala-lang.org/browse/SI-8738?jql=project%20%3D%20SI%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20%3D%20%22Scala%202.11.2%22%20AND%20component%20%3D%20Collections%20ORDER%20BY%20priority%20DESC) were resolved, most notably equality on ranges ([SI-8738](https://issues.scala-lang.org/browse/SI-8738)).
+* The optimizer no longer eliminates division instructions that may throw an `ArithmeticException` ([SI-7607](https://issues.scala-lang.org/browse/SI-7607)).
+* The `-Xlint` compiler flag is now parametrized by individual warnings. This is intended to replace the `-Ywarn-...` options, for instance, `-Xlint:nullary-unit` is equivalent to `-Ywarn-nullary-unit`. Run `scalac -Xlint:help` to see all available options. Kudos to [@som-snytt](https://github.com/som-snytt)!
 
-We apologize for the breakage. We have included a new suite of tests that will ensure stability of serialization for the remainder of the 2.11.x series.
+Compared to 2.11.1, this release resolves [49 issues](https://issues.scala-lang.org/browse/SI-8738?jql=project%20%3D%20SI%20AND%20fixVersion%20%3D%20%22Scala%202.11.2%22%20AND%20resolution%20%3D%20fixed%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC). We reviewed and merged [70 pull requests](https://github.com/scala/scala/issues?milestone=38&state=closed).
 
-<!--break-->
-
-Compared to 2.11.0, this release fixes [26 issues](https://issues.scala-lang.org/browse/SI-8549?jql=project%20%3D%20SI%20AND%20fixVersion%20%3D%20%22Scala%202.11.1%22%20AND%20resolution%20%3D%20fixed%20ORDER%20BY%20priority%20DESC). We reviewed and merged [51 pull requests](https://github.com/scala/scala/issues?milestone=34&state=closed).
-
-The next minor Scala 2.11 release will be available in at most 2 months, or sooner if prompted by a serious issue.
+The next minor Scala 2.11 release will be available in 2 months, or sooner if prompted by a serious issue.
 
 The remainder of these release notes summarizes the 2.11.x series, and as such is not specific to this minor release.
 
@@ -24,7 +20,7 @@ The remainder of these release notes summarizes the 2.11.x series, and as such i
 Code that compiled on 2.10.x without deprecation warnings should compile on 2.11.x (we do not guarantee this for experimental APIs, such as reflection). If not, [please file a regression](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11808&labels=regression). We are working with the community to ensure availability of the core projects of the Scala 2.11.x eco-system, please see below for a list. This release is *not* binary compatible with the 2.10.x series, to allow us to keep improving the Scala standard library.
 
 ### Required Java Version
-The Scala 2.11.x series targets Java 6, with (evolving) experimental support for Java 8. In 2.11.1, Java 8 support is mostly limited to reading Java 8 bytecode and parsing Java 8 source. Stay tuned for more complete (experimental) Java 8 support. The next major release, 2.12, will most likely target Java 8 by default.
+The Scala 2.11.x series targets Java 6, with (evolving) experimental support for Java 8. In 2.11.2, Java 8 support is mostly limited to reading Java 8 bytecode and parsing Java 8 source. Stay tuned for more complete (experimental) Java 8 support. The next major release, 2.12, will most likely target Java 8 by default.
 
 ### New features in the 2.11 series
 This release contains all of the bug fixes and improvements made in the 2.10 series, as well as:
@@ -36,7 +32,7 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * `List` has improved performance on `map`, `flatMap`, and `collect`.
   * See also Deprecation above: we have slated many classes and methods to become final, to clarify which classes are not meant to be subclassed and to facilitate future maintenance and performance improvements.
 * Modularization
-  * The core Scala standard library jar has shed 20% of its bytecode. The modules for xml, parsing, swing as well as the (unsupported) continuations plugin and library are available individually or via [scala-library-all](http://search.maven.org/#artifactdetails%7Corg.scala-lang%7Cscala-library-all%7C2.11.1%7Cpom). Note that this artifact has weaker binary compatibility guarantees than `scala-library` -- as explained above.
+  * The core Scala standard library jar has shed 20% of its bytecode. The modules for xml, parsing, swing as well as the (unsupported) continuations plugin and library are available individually or via [scala-library-all](http://search.maven.org/#artifactdetails%7Corg.scala-lang%7Cscala-library-all%7C2.11.2%7Cpom). Note that this artifact has weaker binary compatibility guarantees than `scala-library` -- as explained above.
   * The compiler has been modularized internally, to separate the presentation compiler, scaladoc and the REPL. We hope this will make it easier to contribute. In this release, all of these modules are still packaged in scala-compiler.jar. We plan to ship them in separate JARs in 2.12.x.
 * Reflection, macros and quasiquotes
   * Please see [this detailed changelog](http://docs.scala-lang.org/overviews/macros/changelog211.html) that lists all significant changes and provides advice on forward and backward compatibility.
@@ -47,12 +43,12 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * A new experimental way of compiling closures, implemented by [@JamesIry](https://github.com/JamesIry). With `-Ydelambdafy:method` anonymous functions are compiled faster, with a smaller bytecode footprint. This works by keeping the function body as a private (static, if no `this` reference is needed) method of the enclosing class, and at the last moment during compilation emitting a small anonymous class that `extends FunctionN` and delegates to it. This sets the scene for a smooth migration to Java 8-style lambdas (not yet implemented).
   * Branch elimination through constant analysis [#2214](https://github.com/scala/scala/pull/2214)
   * [Scala.js](http://www.scala-js.org/), a separate project, provides an experimental JavaScript back-end for Scala 2.11. Note that it is not part of the standard Scala distribution.
-  * Be more [Avian](http://oss.readytalk.com/avian/)- [friendly](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.0-M1%22%20and%20fixVersion%20%3C%3D%20%22Scala%202.11.1%22%20and%20resolution%20%3D%20fixed%20and%20text%20~%20%22avian%22).
+  * Be more [Avian](http://oss.readytalk.com/avian/)- [friendly](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.0-M1%22%20and%20fixVersion%20%3C%3D%20%22Scala%202.11.2%22%20and%20resolution%20%3D%20fixed%20and%20text%20~%20%22avian%22).
 * Compiler Performance
   * Incremental compilation has been improved significantly. To try it out, upgrade to sbt 0.13.2 and add `incOptions := incOptions.value.withNameHashing(true)` to your build! Other build tools are also supported. More info at [this sbt issue](https://github.com/sbt/sbt/issues/1010) -- that's where most of the work happened. More features are planned, e.g. [class-based tracking](https://github.com/sbt/sbt/issues/1104).
   * We've been optimizing the batch compiler's performance as well, and will continue to work on this during the 2.11.x cycle.
   * Improve performance of reflection [SI-6638](https://issues.scala-lang.org/browse/SI-6638)
-* The IDE received [numerous bug fixes and improvements!](https://issues.scala-lang.org/browse/SI-8085?jql=component%20%3D%20%22Presentation%20Compiler%22%20AND%20project%20%3D%20SI%20AND%20resolution%20%3D%20fixed%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.0-M1%22%20and%20fixVersion%20%3C%3D%20%20%22Scala%202.11.1%22%20ORDER%20BY%20updated%20DESC)
+* The IDE received [numerous bug fixes and improvements!](https://issues.scala-lang.org/browse/SI-8085?jql=component%20%3D%20%22Presentation%20Compiler%22%20AND%20project%20%3D%20SI%20AND%20resolution%20%3D%20fixed%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.0-M1%22%20and%20fixVersion%20%3C%3D%20%20%22Scala%202.11.2%22%20ORDER%20BY%20updated%20DESC)
 * REPL
   * The bytecode decompiler command, :javap, now works with Java 7 [SI-4936](https://issues.scala-lang.org/browse/SI-4936) and has sprouted new options [SI-6894](https://issues.scala-lang.org/browse/SI-6894) (Thanks, [@som-snytt](https://github.com/som-snytt)!)
   * Added command :kind to help to tell ground types from type constructors. [#2340](https://github.com/scala/scala/pull/2340) (Thanks, [George Leontiev](https://github.com/folone) and [Eugene Yokota](https://github.com/eed3si9n)!)
@@ -65,20 +61,20 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * Scala 2.10 shipped with new implementations of the Pattern Matcher and the Bytecode Emitter. We have removed the old implementations.
   * Search and destroy mission for ~5000 chunks of dead code. [#1648](https://github.com/scala/scala/pull/1648/files)
 
-The Scala team and contributors [fixed 655 bugs](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20>%3D%20"Scala%202.11.0-M1"%20and%20fixVersion%20<%3D%20"Scala%202.11.1"%20and%20resolution%20%3D%20fixed) that are exclusive to Scala 2.11! We also backported as many as possible. With the release of 2.11, 2.10 backports will be dialed back.
+The Scala team and contributors [fixed 706 bugs](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20>%3D%20"Scala%202.11.0-M1"%20and%20fixVersion%20<%3D%20"Scala%202.11.2"%20and%20resolution%20%3D%20fixed) that are exclusive to Scala 2.11! We also backported as many as possible. With the release of 2.11, 2.10 backports will be dialed back.
 
 A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, participating in mailing lists and other public fora, and -- of course -- submitting and reviewing pull requests! You are all awesome.
 
-Concretely, according to `git log --no-merges --oneline 2.11.x --not 2.10.x --format='%aN'  | sort | uniq -c | sort -rn`, 115 people contributed code, tests, and/or documentation to Scala 2.11.x: Paul Phillips, Jason Zaugg, Eugene Burmako, Adriaan Moors, A. P. Marki, Simon Ochsenreither, Den Shabalin, Miguel Garcia, James Iry, Iain McGinniss, Grzegorz Kossakowski, Rex Kerr, François Garillot, Vladimir Nikolaev, Eugene Vigdorchik, Lukas Rytz, Mirco Dotta, Rüdiger Klaehn, Antoine Gourlay, Raphael Jolly, Simon Schaefer, Kenji Yoshida, Paolo Giarrusso, Luc Bourlier, Hubert Plociniczak, Aleksandar Prokopec, Vlad Ureche, Lex Spoon, Andrew Phillips, Sébastien Doeraene, Josh Suereth, Jean-Remi Desjardins, Vojin Jovanovic, Viktor Klang, Valerian, Prashant Sharma, Pavel Pavlov, Michael Thorpe, Jan Niehusmann, Iulian Dragos, Heejong Lee, George Leontiev, Daniel C. Sobral, Christoffer Sawicki, yllan, rjfwhite, Volkan Yazıcı, Ruslan Shevchenko, Robin Green, Roberto Tyley, Olivier Blanvillain, Mark Harrah, James Ward, Ilya Maykov, Eugene Yokota, Erik Osheim, Dan Hopkins, Chris Hodapp, Antonio Cunei, Andriy Polishchuk, Alexander Clare, 杨博, srinivasreddy, secwall, nermin, martijnhoekstra, kurnevsky, jinfu-leng, folone, Yaroslav Klymko, Xusen Yin, Trent Ogren, Tobias Schlatter, Thomas Geier, Stuart Golodetz, Stefan Zeiger, Scott Carey, Samy Dindane, Sagie Davidovich, Runar Bjarnason, Roland Kuhn, Robert Nix, Robert Ladstätter, Rike-Benjamin Schuppner, Rajiv, Philipp Haller, Nada Amin, Mike Morearty, Michael Bayne, Marcin Kubala, Luke Cycon, Lee Mighdoll, Konstantin Fedorov, Julio Santos, Julien Richard-Foy, Juha Heljoranta, Johannes Rudolph, Jiawei Li, Jentsch, Jason Swartz, James Roper, Heather Miller, Havoc Pennington, Guillaume Martres, Evgeny Kotelnikov, Dmitry Petrashko, Dmitry Bushev, David Hall, Daniel Darabos, Dan Rosen, Cody Allen, Carlo Dapor, Brian McKenna, Andrey Kutejko, Alden Torres.
+Concretely, according to `git log --no-merges --oneline 2.11.x --not 2.10.x --format='%aN'  | sort | uniq -c | sort -rn`, 120 people contributed code, tests, and/or documentation to Scala 2.11.x: Paul Phillips, Jason Zaugg, Eugene Burmako, Adriaan Moors, A. P. Marki, Simon Ochsenreither, Den Shabalin, Miguel Garcia, Denys Shabalin, James Iry, Rex Kerr, Iain McGinniss, Lukas Rytz, Grzegorz Kossakowski, Vladimir Nikolaev, Eugene Vigdorchik, François Garillot, Antoine Gourlay, Mirco Dotta, Rüdiger Klaehn, Raphael Jolly, Paolo Giarrusso, Kenji Yoshida, Hubert Plociniczak, Aleksandar Prokopec, Simon Schaefer, Lex Spoon, Jean-Remi Desjardins, Andrew Phillips, Vlad Ureche, Tobias Roeser, Sébastien Doeraene, Philipp Haller, Luc Bourlier, Josh Suereth, Chris Hodapp, Vojin Jovanovic, Viktor Klang, Valerian, Prashant Sharma, Pavel Pavlov, Michael Thorpe, Jan Niehusmann, Heejong Lee, George Leontiev, Daniel C. Sobral, Christoffer Sawicki, yllan, rjfwhite, Volkan Yazıcı, Todd Vierling, Ruslan Shevchenko, Robin Green, Olivier Blanvillain, Marcin Kubala, Johannes Rudolph, Iulian Dragos, Ilya Maykov, Eugene Yokota, Erik Osheim, Dan Hopkins, Antonio Cunei, Andriy Polishchuk, Alexander Clare, 杨博, srinivasreddy, secwall, nermin, martijnhoekstra, kurnevsky, jinfu-leng, folone, Yaroslav Klymko, Xusen Yin, Trent Ogren, Tobias Schlatter, Thomas Geier, Stuart Golodetz, Stephen Compall, Stefan Zeiger, Scott Carey, Samy Dindane, Sagie Davidovich, Runar Bjarnason, Rui Gonçalves, Roland Kuhn, Roberto Tyley, Robert Nix, Robert Ladstätter, Rike-Benjamin Schuppner, Rajiv, Nada Amin, Mike Morearty, Michael Bayne, Martin Odersky, Mark Harrah, Luke Cycon, Lee Mighdoll, Konstantin Fedorov, Julio Santos, Julien Richard-Foy, Juha Heljoranta, Jiawei Li, Jentsch, Jason Swartz, James Ward, James Roper, Havoc Pennington, Guillaume Martres, Evgeny Kotelnikov, Dmitry Petrashko, Dmitry Bushev, David Hall, Daniel Darabos, Dan Rosen, Cody Allen, Carlo Dapor, Brian McKenna, Andrey Kutejko, Alden Torres.
 
 Thank you all very much.
 
-If you find any errors or omissions in these relates notes, [please submit a PR](https://github.com/scala/make-release-notes/blob/master/hand-written.md)!
+If you find any errors or omissions in these relates notes, [please submit a PR](https://github.com/scala/make-release-notes/blob/2.11.x/hand-written.md)!
 
 ### Reporting Bugs / Known Issues
 Please [file any bugs you encounter](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11311). If you're unsure whether something is a bug, please contact the [scala-user](https://groups.google.com/forum/?fromgroups#!forum/scala-user) mailing list.
 
-Before reporting a bug, please have a look at these [known issues](https://issues.scala-lang.org/browse/SI-6267?jql=project%20%3D%20SI%20AND%20(fixVersion%20is%20empty%20or%20fixVersion%20%3E%20%22Scala%202.11.1%22)%20AND%20affectedVersion%20in%20(%22Scala%202.11.0%22%2C%20%22Scala%202.11.1%22)%20%20and%20resolution%20%3D%20unresolved%20ORDER%20BY%20priority%20DESC).
+Before reporting a bug, please have a look at these [known issues](https://issues.scala-lang.org/browse/SI-6267?jql=project%20%3D%20SI%20AND%20(fixVersion%20is%20empty%20or%20fixVersion%20%3E%20%22Scala%202.11.2%22)%20AND%20affectedVersion%20in%20(%22Scala%202.11.0%22%2C%20%22Scala%202.11.1%22%2C%20%22Scala%202.11.2%22)%20%20and%20resolution%20%3D%20unresolved%20ORDER%20BY%20priority%20DESC).
 
 ### Scala IDE for Eclipse
 The Scala IDE with this release built in is [available from this update site](http://download.scala-ide.org/ecosystem/helium/e38/scala211/stable/site/) for [Eclipse 4.2/4.3 (Juno/Kepler)](http://www.eclipse.org/downloads/packages/eclipse-ide-java-developers/keplersr2). Please have a look at the [getting started guide](http://scala-ide.org/docs/user/gettingstarted.html) for more info.
@@ -87,7 +83,7 @@ The Scala IDE with this release built in is [available from this update site](ht
 ### Available projects
 The following Scala projects have already been released against 2.11! See also [@jrudolph's analysis](https://gist.github.com/jrudolph/7a323f5e2820d8479b18) of the availability of 2.11 builds of popular libraries (as well as which ones are missing); updated regularly.
 
-We'd love to include your release in this list as soon as it's available -- please submit a PR to update [these release notes](https://github.com/scala/make-release-notes/blob/master/hand-written.md).
+We'd love to include your release in this list as soon as it's available -- please submit a PR to update [these release notes](https://github.com/scala/make-release-notes/blob/2.11.x/hand-written.md).
 
     "org.scalacheck"                   %% "scalacheck"                % "1.11.4"
     "org.scalatest"                    %% "scalatest"                 % "2.1.7"
@@ -147,9 +143,9 @@ When cross-building between Scala versions, you often need to vary the versions 
 
 Here's how we recommend handling this in sbt 0.13. For the full build and Maven build, see [example](https://github.com/scala/scala-module-dependency-sample).
 
-    scalaVersion        := "2.11.1"
+    scalaVersion        := "2.11.2"
 
-    crossScalaVersions  := Seq("2.11.1", "2.10.3")
+    crossScalaVersions  := Seq("2.11.2", "2.10.4")
 
     // add scala-xml dependency when needed (for Scala 2.11 and newer)
     // this mechanism supports cross-version publishing
@@ -179,7 +175,7 @@ The following changes were made after a deprecation cycle (Thank you, [@soc](htt
 
 Finally, some notable improvements and bug fixes:
 
-* [SI-8549](https://issues.scala-lang.org/browse/SI-8549) Fix bad regression: no `serialVersionUID` field for classes annotated with [@SerialVersionUID](http://www.scala-lang.org/api/2.11.1/index.html#scala.SerialVersionUID). The Scala standard library itself was a victim of this bug. As such, collections serialized in 2.11.0 will not be able to be deserialized in 2.11.1. This regression occurred in a failed [attempt](https://github.com/scala/scala/pull/1673) to fix a related bug in 2.10.x, [SI-6988](https://issues.scala-lang.org/browse/SI-6988), whereby classes annotated with non literal UIDS, e.g. `0L - 123L`, had no field generated. 
+* [SI-8549](https://issues.scala-lang.org/browse/SI-8549) Fix bad regression: no `serialVersionUID` field for classes annotated with [@SerialVersionUID](http://www.scala-lang.org/api/2.11.2/index.html#scala.SerialVersionUID). The Scala standard library itself was a victim of this bug. As such, collections serialized in 2.11.0 will not be able to be deserialized in 2.11.1. This regression occurred in a failed [attempt](https://github.com/scala/scala/pull/1673) to fix a related bug in 2.10.x, [SI-6988](https://issues.scala-lang.org/browse/SI-6988), whereby classes annotated with non literal UIDS, e.g. `0L - 123L`, had no field generated. 
 * [SI-7296](https://issues.scala-lang.org/browse/SI-7296) Case classes with > 22 parameters are now allowed.
 * [SI-3346](https://issues.scala-lang.org/browse/SI-3346) Implicit arguments of implicit conversions now guide type inference.
 * [SI-6240](https://issues.scala-lang.org/browse/SI-6240) Thread safety of reflection API.

--- a/hand-written.md
+++ b/hand-written.md
@@ -79,21 +79,19 @@ Please [file any bugs you encounter](https://issues.scala-lang.org/secure/Create
 Before reporting a bug, please have a look at these [known issues](https://issues.scala-lang.org/browse/SI-6267?jql=project%20%3D%20SI%20AND%20(fixVersion%20is%20empty%20or%20fixVersion%20%3E%20%22Scala%202.11.1%22)%20AND%20affectedVersion%20in%20(%22Scala%202.11.0%22%2C%20%22Scala%202.11.1%22)%20%20and%20resolution%20%3D%20unresolved%20ORDER%20BY%20priority%20DESC).
 
 ### Scala IDE for Eclipse
-The Scala IDE with this release built in will soon be available.
-<!-- 
+The Scala IDE with this release built in is [available from this update site](http://download.scala-ide.org/ecosystem/helium/e38/scala211/stable/site/) for [Eclipse 4.2/4.3 (Juno/Kepler)](http://www.eclipse.org/downloads/packages/eclipse-ide-java-developers/keplersr2). Please have a look at the [getting started guide](http://scala-ide.org/docs/user/gettingstarted.html) for more info.
 
-is [available from this update site](http://download.scala-ide.org/sdk/helium/e38/scala211/stable/site/) for [Eclipse 4.2/4.3 (Juno/Kepler)](http://www.eclipse.org/downloads/packages/eclipse-ide-java-developers/keplersr2). Please have a look at the [getting started guide](http://scala-ide.org/docs/user/gettingstarted.html) for more info.
-
--->
 
 ### Available projects
-The following Scala projects have already been released against 2.11! We'd love to include yours in this list as soon as it's available -- please submit a PR to update [these release notes](https://github.com/scala/make-release-notes/blob/master/hand-written.md).
+The following Scala projects have already been released against 2.11! See also [@jrudolph's analysis](https://gist.github.com/jrudolph/7a323f5e2820d8479b18) of the availability of 2.11 builds of popular libraries (as well as which ones are missing); updated regularly.
 
-    "org.scalacheck"                   %% "scalacheck"                % "1.11.3"
-    "org.scalatest"                    %% "scalatest"                 % "2.1.3"
+We'd love to include your release in this list as soon as it's available -- please submit a PR to update [these release notes](https://github.com/scala/make-release-notes/blob/master/hand-written.md).
+
+    "org.scalacheck"                   %% "scalacheck"                % "1.11.4"
+    "org.scalatest"                    %% "scalatest"                 % "2.1.7"
     "org.scalautils"                   %% "scalautils"                % "2.1.3"
     "com.typesafe.akka"                %% "akka-actor"                % "2.3.2"
-    "com.typesafe.scala-logging"       %% "scala-logging-slf4j"       % "2.0.4"
+    "com.typesafe.scala-logging"       %% "scala-logging-slf4j"       % "2.1.2"
     "org.scala-lang.modules"           %% "scala-async"               % "0.9.1"
     "org.scalikejdbc"                  %% "scalikejdbc-interpolation" % "2.0.0-beta1"
     "com.softwaremill.scalamacrodebug" %% "macros"                    % "0.4"
@@ -121,9 +119,10 @@ The following Scala projects have already been released against 2.11! We'd love 
     "org.typelevel"                    %% "scodec-core"               % "1.0.0"
     "com.sksamuel.scrimage"            %% "scrimage"                  % "1.3.20"
     "net.databinder"                   %% "dispatch-http"             % "0.8.10"
+    "net.databinder"                   %% "unfiltered"                % "0.8.0"
     "net.databinder"                   %% "unfiltered"                % "0.7.1"
     "io.argonaut"                      %% "argonaut"                  % "6.0.4"
-    "org.specs2"                       %% "specs2"                    % "2.3.11"
+    "org.specs2"                       %% "specs2"                    % "2.3.12"
     "com.propensive"                   %% "rapture-core"              % "0.9.0"
     "com.propensive"                   %% "rapture-json"              % "0.9.1"
     "com.propensive"                   %% "rapture-io"                % "0.9.1"
@@ -136,6 +135,10 @@ The following Scala projects have already been released against 2.11! We'd love 
     "org.mongodb"                      %% "casbah"                    % "2.7.1"
     "com.clarifi"                      %% "f0"                        % "1.1.2"
     "org.scalaj"                       %% "scalaj-http"               % "0.3.15"
+
+The following libraries are specific to the 2.11.x minor release you're using. If you depend on them, you should also cross-version fully!
+
+    "org.scalamacros"                   % "paradise"                  % "2.0.0" cross CrossVersion.full
 
 ### Cross-building with sbt 0.13
 When cross-building between Scala versions, you often need to vary the versions of your dependencies. In particular, the new scala modules (such as scala-xml) are no longer included in scala-library, so you'll have to add an explicit dependency on it to use Scala's xml support.

--- a/hand-written.md
+++ b/hand-written.md
@@ -14,9 +14,11 @@ We apologize for the breakage. We have included a new suite of tests that will e
 
 <!--break-->
 
-This release fixes [26 issues](https://issues.scala-lang.org/browse/SI-8549?jql=project%20%3D%20SI%20AND%20fixVersion%20%3D%20%22Scala%202.11.1%22%20AND%20resolution%20%3D%20fixed%20ORDER%20BY%20priority%20DESC). We reviewed and merged [51 pull requests](https://github.com/scala/scala/issues?milestone=34&state=closed).
+Compared to 2.11.0, this release fixes [26 issues](https://issues.scala-lang.org/browse/SI-8549?jql=project%20%3D%20SI%20AND%20fixVersion%20%3D%20%22Scala%202.11.1%22%20AND%20resolution%20%3D%20fixed%20ORDER%20BY%20priority%20DESC). We reviewed and merged [51 pull requests](https://github.com/scala/scala/issues?milestone=34&state=closed).
 
 The next minor Scala 2.11 release will be available in at most 2 months, or sooner if prompted by a serious issue.
+
+The remainder of these release notes summarizes the 2.11.x series, and as such is not specific to this minor release.
 
 ### Upgrading
 Code that compiled on 2.10.x without deprecation warnings should compile on 2.11.x (we do not guarantee this for experimental APIs, such as reflection). If not, [please file a regression](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11808&labels=regression). We are working with the community to ensure availability of the core projects of the Scala 2.11.x eco-system, please see below for a list. This release is *not* binary compatible with the 2.10.x series, to allow us to keep improving the Scala standard library.

--- a/hand-written.md
+++ b/hand-written.md
@@ -1,26 +1,32 @@
-We are very pleased to announce the release of Scala 2.11.2!
+We are very pleased to announce the release of Scala 2.11.4!
 
 * Get started with the [Hello Scala 2.11 template](https://typesafe.com/activator/template/hello-scala-2_11) in [Typesafe Activator](https://typesafe.com/platform/getstarted)
-* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.2.html)
-* Obtain it via [Maven Central](http://search.maven.org/?search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.2%22#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.2%22)
+* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.4.html)
+* Obtain it via [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.4%22)
 
-Scala 2.11.2 is a bugfix release that is binary compatible with previous releases in the Scala 2.11 series.
+Scala 2.11.4 is a bugfix release that is binary compatible with previous releases in the Scala 2.11 series.
 The changes include:
 
-* Several [issues in the collections library](https://issues.scala-lang.org/browse/SI-8738?jql=project%20%3D%20SI%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20%3D%20%22Scala%202.11.2%22%20AND%20component%20%3D%20Collections%20ORDER%20BY%20priority%20DESC) were resolved, most notably equality on ranges ([SI-8738](https://issues.scala-lang.org/browse/SI-8738)).
-* The optimizer no longer eliminates division instructions that may throw an `ArithmeticException` ([SI-7607](https://issues.scala-lang.org/browse/SI-7607)).
-* The `-Xlint` compiler flag is now parameterized by individual warnings. This is intended to replace the `-Ywarn-...` options, for instance, `-Xlint:nullary-unit` is equivalent to `-Ywarn-nullary-unit`. Run `scalac -Xlint:help` to see all available options. Kudos to [@som-snytt](https://github.com/som-snytt)!
-* TypeTags and Exprs are now serializable ([SI-5919](https://issues.scala-lang.org/browse/SI-5919)).
+* Scala shell (REPL) is more friendly to Crtl+D. It leaves your terminal in a clean state and suggests using `:quit` the next
+time (see [#3902](https://github.com/scala/scala/pull/3902). Kudos to [@gourlaysama](https://github.com/gourlaysama)!
+* REPL uses different colors when printing references to vals and types. Pass `-Dscala.color` to enable that behavior (see [#3993](https://github.com/scala/scala/pull/3993)). Thanks to [@puffnfresh](https://github.com/puffnfresh)!
+* [Scala specification](http://www.scala-lang.org/files/archive/spec/2.11/) received a fair amount of love and became much more beatiful.  It has got syntax highlighting ([#3984](https://github.com/scala/scala/pull/3984)), linkable headers, and a side bar with TOC ([#3996](https://github.com/scala/scala/pull/3996)). A few final touches has been merged that fix typos and mistakes stemming from automatic Latex to Markdown conversion we've done a while ago. Thanks attention for details [@gourlaysama](https://github.com/gourlaysama), [@som-snytt](https://github.com/som-snytt) and [roberthoedicke](https://github.com/roberthoedicke)!
+* Non-deterministic pattern matching warnings has been fixed ([SI-7746](https://issues.scala-lang.org/browse/SI-7746)). Many thanks to [@gbasler](https://github.com/gbasler) for diving deep ([#3954](https://github.com/scala/scala/pull/3954])) into logical formulas constructed by our pattern matcher implementation!
 
-Compared to 2.11.1, this release resolves [49 issues](https://issues.scala-lang.org/browse/SI-8738?jql=project%20%3D%20SI%20AND%20fixVersion%20%3D%20%22Scala%202.11.2%22%20AND%20resolution%20%3D%20fixed%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC). We reviewed and merged [70 pull requests](https://github.com/scala/scala/issues?milestone=38&state=closed).
+Compared to 2.11.2, this release resolves [54 issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20in%20(%22Scala%202.11.3%22%2C%20%22Scala%202.11.4%22)%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC). Out of 120, we merged 95 pull requests: [90 for 2.11.3](https://github.com/scala/scala/pulls?q=is%3Apr+is%3Amerged+milestone%3A2.11.3), and [5 for 2.11.4](https://github.com/scala/scala/pulls?q=is%3Apr+is%3Amerged+milestone%3A2.11.4).
 
-The next minor Scala 2.11 release will be available in 2 months, or sooner if prompted by a serious issue.
+The next minor Scala 2.11 release will be available before the end of the year, or sooner if prompted by a serious issue.
+
+### Do Not Use Scala 2.11.3
+Due to a [binary incompatibility](https://issues.scala-lang.org/browse/SI-8899) in Scala 2.11.3, we recommend upgrading to Scala 2.11.4, which resolves the incompatibility, as well as another [blocker issue](https://issues.scala-lang.org/browse/SI-8900) that was discovered in the days after the 2.11.3 release.
+
+We have [analyzed](https://groups.google.com/d/msg/scala-internals/SSD9BNJaFbU/rACBkHrs2JEJ) the mistakes that lead to the breakage (human error), and are taking measures to prevent this from happening again. We apologize for the inconvenience, and thank everyone who was involved in reporting and diagnosing these critical issues.
 
 ### Available Libraries and Frameworks
 
 A large number of Scala projects have been released against Scala 2.11. Please refer to the list of [libraries and frameworks available for Scala 2.11](https://github.com/scala/make-release-notes/blob/2.11.x/projects-2.11.md).
 
-A release of the Scala IDE that includes Scala 2.11.2 will be available shortly [on their download site](http://scala-ide.org/download/sdk.html).
+A release of the Scala IDE that includes Scala 2.11.4 is available [on their download site](http://scala-ide.org/download/milestone.html).
 
 ### Release Notes for the Scala 2.11 Series
 
@@ -31,8 +37,7 @@ The release notes for the Scala 2.11 series, which also apply to the current min
 
 ### Contributors
 
-A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, participating in mailing lists and other public fora, and submitting and reviewing pull requests!
-You are all awesome.
+A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, participating in mailing lists and other public fora, and submitting and reviewing pull requests! You are all awesome.
 
-According to `git shortlog -sn --no-merges v2.11.1..v2.11.2`, 21 people contributed code to this minor release:
-Jason Zaugg, A. P. Marki, Lukas Rytz, Adriaan Moors, Rex Kerr, Eugene Burmako, Antoine Gourlay, Tobias Roeser, Denys Shabalin, Philipp Haller, Chris Hodapp, Todd Vierling, Vladimir Nikolaev, François Garillot, Jean-Remi Desjardins, Johannes Rudolph, Marcin Kubala, Martin Odersky, Paolo Giarrusso, Rui Gonçalves, Stephen Compall.
+According to `git shortlog -sn --no-merges v2.11.2..v2.11.4`, 35 people contributed to this minor release:
+Lukas Rytz, Adriaan Moors, Antoine Gourlay, A. P. Marki, Jason Zaugg, Robert Hoedicke, Eugene Burmako, Rex Kerr, Max Bileschi, Brian McKenna, Grzegorz Kossakowski, Maks Atygaev, Evgeny Vereshchagin, Simon Ochsenreither, Dominik Gruntz, Masato Sogame, Gerard Basler, Dan Garrette, Artem Stasuk, David Turner, Iulian Dragos, Jeroen ter Voorde, Kato Kazuyoshi, Konstantin Fedorov, Krystian Nowak, Lukas Elmer, Malte Isberner, Paolo Giarrusso, Paweł Wiejacha, Robert Hoedicke, dgruntz, Roman Janusz, harryhuk, Michał Pociecha.

--- a/hand-written.md
+++ b/hand-written.md
@@ -1,32 +1,32 @@
-We are very pleased to announce the release of Scala 2.11.4!
+We are very pleased to announce the release of Scala 2.11.5!
 
 * Get started with the [Hello Scala 2.11 template](https://typesafe.com/activator/template/hello-scala-2_11) in [Typesafe Activator](https://typesafe.com/platform/getstarted)
-* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.4.html)
-* Obtain it via [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.4%22)
+* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.5.html)
+* Obtain it via [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.5%22)
 
-Scala 2.11.4 is a bugfix release that is binary compatible with previous releases in the Scala 2.11 series.
-The changes include:
+Scala 2.11.5 is a bugfix release that is binary compatible with previous releases in the Scala 2.11 series. We would like to highlight the following changes:
 
-* Scala shell (REPL) is more friendly to Crtl+D. It leaves your terminal in a clean state and suggests using `:quit` the next
-time (see [#3902](https://github.com/scala/scala/pull/3902). Kudos to [@gourlaysama](https://github.com/gourlaysama)!
-* REPL uses different colors when printing references to vals and types. Pass `-Dscala.color` to enable that behavior (see [#3993](https://github.com/scala/scala/pull/3993)). Thanks to [@puffnfresh](https://github.com/puffnfresh)!
-* [Scala specification](http://www.scala-lang.org/files/archive/spec/2.11/) received a fair amount of love and became much more beatiful.  It has got syntax highlighting ([#3984](https://github.com/scala/scala/pull/3984)), linkable headers, and a side bar with TOC ([#3996](https://github.com/scala/scala/pull/3996)). A few final touches has been merged that fix typos and mistakes stemming from automatic Latex to Markdown conversion we've done a while ago. Thanks attention for details [@gourlaysama](https://github.com/gourlaysama), [@som-snytt](https://github.com/som-snytt) and [roberthoedicke](https://github.com/roberthoedicke)!
-* Non-deterministic pattern matching warnings has been fixed ([SI-7746](https://issues.scala-lang.org/browse/SI-7746)). Many thanks to [@gbasler](https://github.com/gbasler) for diving deep ([#3954](https://github.com/scala/scala/pull/3954])) into logical formulas constructed by our pattern matcher implementation!
+ - @heathermiller's [SI-6502 Reenables loading jars into the running REPL](https://github.com/scala/scala/pull/4051)
+ - @mpociecha's [The alternative, flat representation of classpath elements](https://github.com/scala/scala/pull/4176)
+ - @gbasler's [Avoid the 'CNF budget exceeded' exception via smarter translation into CNF](https://github.com/scala/scala/pull/4078)
+ - @adriaanm's [SAMmy: eta-expansion, overloading, existentials](https://github.com/scala/scala/pull/4101)
+ - A great number of documentation improvements -- thank you (and, to those appearing for the first time in our release notes, welcome!): @kanielc, @lymia, @stevegury, @vigdorchik, @gourlaysama, @ichoran, @retronym, @xuwei-k, @dickwall, @phaller.
 
-Compared to 2.11.2, this release resolves [54 issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20in%20(%22Scala%202.11.3%22%2C%20%22Scala%202.11.4%22)%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC). Out of 120, we merged 95 pull requests: [90 for 2.11.3](https://github.com/scala/scala/pulls?q=is%3Apr+is%3Amerged+milestone%3A2.11.3), and [5 for 2.11.4](https://github.com/scala/scala/pulls?q=is%3Apr+is%3Amerged+milestone%3A2.11.4).
+Compared to 2.11.4, this release resolves [74 issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20in%20%28%22Scala%202.11.5%22%29%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC). Out of 132, we [merged 110 pull requests](https://github.com/scala/scala/pulls?q=is%3Apr+is%3Amerged+milestone%3A2.11.5). Before upgrading, please also check the [known issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20status%3Dopen%20AND%20affectedVersion%20%3D%20%22Scala%202.11.5%22%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.5%22%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC) for this release.
 
 The next minor Scala 2.11 release will be available before the end of the year, or sooner if prompted by a serious issue.
 
-### Do Not Use Scala 2.11.3
-Due to a [binary incompatibility](https://issues.scala-lang.org/browse/SI-8899) in Scala 2.11.3, we recommend upgrading to Scala 2.11.4, which resolves the incompatibility, as well as another [blocker issue](https://issues.scala-lang.org/browse/SI-8900) that was discovered in the days after the 2.11.3 release.
-
-We have [analyzed](https://groups.google.com/d/msg/scala-internals/SSD9BNJaFbU/rACBkHrs2JEJ) the mistakes that lead to the breakage (human error), and are taking measures to prevent this from happening again. We apologize for the inconvenience, and thank everyone who was involved in reporting and diagnosing these critical issues.
+### Scala IDE
+The current release of Scala IDE includes Scala 2.11.5 is available on the [download site](http://scala-ide.org/download/sdk.html) (or as an update to version 4.0 of the plugin).
 
 ### Available Libraries and Frameworks
 
 A large number of Scala projects have been released against Scala 2.11. Please refer to the list of [libraries and frameworks available for Scala 2.11](https://github.com/scala/make-release-notes/blob/2.11.x/projects-2.11.md).
 
-A release of the Scala IDE that includes Scala 2.11.4 is available [on their download site](http://scala-ide.org/download/milestone.html).
+### Reminder: Do Not Use Scala 2.11.3
+Due to a [binary incompatibility](https://issues.scala-lang.org/browse/SI-8899) in Scala 2.11.3, we recommend upgrading to Scala 2.11.5, which resolves the incompatibility, as well as another [blocker issue](https://issues.scala-lang.org/browse/SI-8900) that was discovered in the days after the 2.11.3 release.
+
+We have [analyzed](https://groups.google.com/d/msg/scala-internals/SSD9BNJaFbU/rACBkHrs2JEJ) the mistakes that lead to the breakage (human error), and are taking measures to prevent this from happening again. We apologize for the inconvenience, and thank everyone who was involved in reporting and diagnosing these critical issues.
 
 ### Release Notes for the Scala 2.11 Series
 
@@ -39,5 +39,5 @@ The release notes for the Scala 2.11 series, which also apply to the current min
 
 A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, participating in mailing lists and other public fora, and submitting and reviewing pull requests! You are all awesome.
 
-According to `git shortlog -sn --no-merges v2.11.2..v2.11.4`, 35 people contributed to this minor release:
-Lukas Rytz, Adriaan Moors, Antoine Gourlay, A. P. Marki, Jason Zaugg, Robert Hoedicke, Eugene Burmako, Rex Kerr, Max Bileschi, Brian McKenna, Grzegorz Kossakowski, Maks Atygaev, Evgeny Vereshchagin, Simon Ochsenreither, Dominik Gruntz, Masato Sogame, Gerard Basler, Dan Garrette, Artem Stasuk, David Turner, Iulian Dragos, Jeroen ter Voorde, Kato Kazuyoshi, Konstantin Fedorov, Krystian Nowak, Lukas Elmer, Malte Isberner, Paolo Giarrusso, Paweł Wiejacha, Robert Hoedicke, dgruntz, Roman Janusz, harryhuk, Michał Pociecha.
+According to `git shortlog -sn --no-merges v2.11.4..v2.11.5`, 30 people contributed to this minor release:
+Jason Zaugg, Lukas Rytz, Michał Pociecha, A. P. Marki, Antoine Gourlay, Heather Miller, Adriaan Moors, Rex Kerr, Simon Ochsenreither, Gerard Basler, Denton Cockburn, Kenji Yoshida, Ye Xianjin, Guy Dickinson, Jean-Remi Desjardins, Alissa Rao, Lukasz Piepiora, Maxim Valyanskiy, Paolo Giarrusso, Philipp Haller, Rafał Krzewski, Eugene Vigdorchik, Rui Gonçalves, Erik Erlandson, Steve Gury, Teemu Lehtinen, Tim Harper, Dick Wall, Guillaume Martres, Grzegorz Kossakowski.

--- a/hand-written.md
+++ b/hand-written.md
@@ -16,11 +16,9 @@ Compared to 2.11.1, this release resolves [49 issues](https://issues.scala-lang.
 
 The next minor Scala 2.11 release will be available in 2 months, or sooner if prompted by a serious issue.
 
-### Available Libraries
+### Available Libraries and Frameworks
 
-A large number of Scala projects have been released against Scala 2.11.
-[@jrudolph](https://github.com/jrudolph) is maintaining a list of [library versions for Scala 2.11](https://gist.github.com/jrudolph/7a323f5e2820d8479b18).
-You may also want to check out the [Awesome Scala](https://github.com/lauris/awesome-scala) list of libraries and frameworks maintained by [@lauris](https://github.com/lauris).
+A large number of Scala projects have been released against Scala 2.11. Please refer to the list of [libraries and frameworks available for Scala 2.11](https://github.com/scala/make-release-notes/blob/2.11.x/projects-2.11.md).
 
 A release of the Scala IDE that includes Scala 2.11.2 is available [on their download site](http://scala-ide.org/download/sdk.html).
 

--- a/hand-written.md
+++ b/hand-written.md
@@ -34,5 +34,5 @@ The release notes for the Scala 2.11 series, which also apply to the current min
 A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, participating in mailing lists and other public fora, and submitting and reviewing pull requests!
 You are all awesome.
 
-According to `git log --no-merges --oneline v2.11.2 --not v2.11.1 --format='%aN' | sort | uniq -c | sort -rn`, 21 people contributed code to this minor release:
-Jason Zaugg, A. P. Marki, Lukas Rytz, Adriaan Moors, Rex Kerr, Eugene Burmako, Antoine Gourlay, Tobias Roeser, Philipp Haller, Denys Shabalin, Todd Vierling, Chris Hodapp, Vladimir Nikolaev, Stephen Compall, Rui Gonçalves, Paolo Giarrusso, Martin Odersky, Marcin Kubala, Johannes Rudolph, Jean-Remi Desjardins, François Garillot.
+According to `git shortlog -sn --no-merges v2.11.1..v2.11.2`, 21 people contributed code to this minor release:
+Jason Zaugg, A. P. Marki, Lukas Rytz, Adriaan Moors, Rex Kerr, Eugene Burmako, Antoine Gourlay, Tobias Roeser, Denys Shabalin, Philipp Haller, Chris Hodapp, Todd Vierling, Vladimir Nikolaev, François Garillot, Jean-Remi Desjardins, Johannes Rudolph, Marcin Kubala, Martin Odersky, Paolo Giarrusso, Rui Gonçalves, Stephen Compall.

--- a/hand-written.md
+++ b/hand-written.md
@@ -4,242 +4,37 @@ We are very pleased to announce the release of Scala 2.11.2!
 * Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.2.html)
 * Obtain it via [Maven Central](http://search.maven.org/?search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.2%22#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.2%22)
 
-Scala 2.11.2 is a bugfix release that is binary compatible with previous releases in the Scala 2.11 series. The changes include:
+Scala 2.11.2 is a bugfix release that is binary compatible with previous releases in the Scala 2.11 series.
+The changes include:
 
 * Several [issues in the collections library](https://issues.scala-lang.org/browse/SI-8738?jql=project%20%3D%20SI%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20%3D%20%22Scala%202.11.2%22%20AND%20component%20%3D%20Collections%20ORDER%20BY%20priority%20DESC) were resolved, most notably equality on ranges ([SI-8738](https://issues.scala-lang.org/browse/SI-8738)).
 * The optimizer no longer eliminates division instructions that may throw an `ArithmeticException` ([SI-7607](https://issues.scala-lang.org/browse/SI-7607)).
-* The `-Xlint` compiler flag is now parametrized by individual warnings. This is intended to replace the `-Ywarn-...` options, for instance, `-Xlint:nullary-unit` is equivalent to `-Ywarn-nullary-unit`. Run `scalac -Xlint:help` to see all available options. Kudos to [@som-snytt](https://github.com/som-snytt)!
+* The `-Xlint` compiler flag is now parameterized by individual warnings. This is intended to replace the `-Ywarn-...` options, for instance, `-Xlint:nullary-unit` is equivalent to `-Ywarn-nullary-unit`. Run `scalac -Xlint:help` to see all available options. Kudos to [@som-snytt](https://github.com/som-snytt)!
+* TypeTags and Exprs are now serializable ([SI-5919](https://issues.scala-lang.org/browse/SI-5919)).
 
 Compared to 2.11.1, this release resolves [49 issues](https://issues.scala-lang.org/browse/SI-8738?jql=project%20%3D%20SI%20AND%20fixVersion%20%3D%20%22Scala%202.11.2%22%20AND%20resolution%20%3D%20fixed%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC). We reviewed and merged [70 pull requests](https://github.com/scala/scala/issues?milestone=38&state=closed).
 
 The next minor Scala 2.11 release will be available in 2 months, or sooner if prompted by a serious issue.
 
-The remainder of these release notes summarizes the 2.11.x series, and as such is not specific to this minor release.
+### Available Libraries
 
-### Upgrading
-Code that compiled on 2.10.x without deprecation warnings should compile on 2.11.x (we do not guarantee this for experimental APIs, such as reflection). If not, [please file a regression](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11808&labels=regression). We are working with the community to ensure availability of the core projects of the Scala 2.11.x eco-system, please see below for a list. This release is *not* binary compatible with the 2.10.x series, to allow us to keep improving the Scala standard library.
+A large number of Scala projects have been released against Scala 2.11.
+[@jrudolph](https://github.com/jrudolph) is maintaining a list of [library versions for Scala 2.11](https://gist.github.com/jrudolph/7a323f5e2820d8479b18).
+You may also want to check out the [Awesome Scala](https://github.com/lauris/awesome-scala) list of libraries and frameworks maintained by [@lauris](https://github.com/lauris).
 
-### Required Java Version
-The Scala 2.11.x series targets Java 6, with (evolving) experimental support for Java 8. In 2.11.2, Java 8 support is mostly limited to reading Java 8 bytecode and parsing Java 8 source. Stay tuned for more complete (experimental) Java 8 support. The next major release, 2.12, will most likely target Java 8 by default.
+A release of the Scala IDE that includes Scala 2.11.2 is available [on their download site](http://scala-ide.org/download/sdk.html).
 
-### New features in the 2.11 series
-This release contains all of the bug fixes and improvements made in the 2.10 series, as well as:
+### Release Notes for the Scala 2.11 Series
 
-* Collections
-  * Immutable `HashMap`s and `HashSet`s perform faster filters, unions, and the like, with improved structural sharing (lower memory usage or churn).
-  * Mutable `LongMap` and `AnyRefMap` have been added to provide improved performance when keys are `Long` or `AnyRef` (performance enhancement of up to 4x or 2x respectively).
-  * `BigDecimal` is more explicit about rounding and numeric representations, and better handles very large values without exhausting memory (by avoiding unnecessary conversions to `BigInt`).
-  * `List` has improved performance on `map`, `flatMap`, and `collect`.
-  * See also Deprecation above: we have slated many classes and methods to become final, to clarify which classes are not meant to be subclassed and to facilitate future maintenance and performance improvements.
-* Modularization
-  * The core Scala standard library jar has shed 20% of its bytecode. The modules for xml, parsing, swing as well as the (unsupported) continuations plugin and library are available individually or via [scala-library-all](http://search.maven.org/#artifactdetails%7Corg.scala-lang%7Cscala-library-all%7C2.11.2%7Cpom). Note that this artifact has weaker binary compatibility guarantees than `scala-library` -- as explained above.
-  * The compiler has been modularized internally, to separate the presentation compiler, scaladoc and the REPL. We hope this will make it easier to contribute. In this release, all of these modules are still packaged in scala-compiler.jar. We plan to ship them in separate JARs in 2.12.x.
-* Reflection, macros and quasiquotes
-  * Please see [this detailed changelog](http://docs.scala-lang.org/overviews/macros/changelog211.html) that lists all significant changes and provides advice on forward and backward compatibility.
-  * See also this [summary](http://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
-  * [#3321](https://github.com/scala/scala/pull/3321) introduced [Sprinter](http://vladimirnik.github.io/sprinter/), a new AST pretty-printing library! Very useful for tools that deal with source code.
-* Back-end
-  * The [GenBCode back-end](https://github.com/scala/scala/pull/2620) (experimental in 2.11). See [@magarciaepfl's extensive documentation](http://magarciaepfl.github.io/scala/).
-  * A new experimental way of compiling closures, implemented by [@JamesIry](https://github.com/JamesIry). With `-Ydelambdafy:method` anonymous functions are compiled faster, with a smaller bytecode footprint. This works by keeping the function body as a private (static, if no `this` reference is needed) method of the enclosing class, and at the last moment during compilation emitting a small anonymous class that `extends FunctionN` and delegates to it. This sets the scene for a smooth migration to Java 8-style lambdas (not yet implemented).
-  * Branch elimination through constant analysis [#2214](https://github.com/scala/scala/pull/2214)
-  * [Scala.js](http://www.scala-js.org/), a separate project, provides an experimental JavaScript back-end for Scala 2.11. Note that it is not part of the standard Scala distribution.
-  * Be more [Avian](http://oss.readytalk.com/avian/)- [friendly](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.0-M1%22%20and%20fixVersion%20%3C%3D%20%22Scala%202.11.2%22%20and%20resolution%20%3D%20fixed%20and%20text%20~%20%22avian%22).
-* Compiler Performance
-  * Incremental compilation has been improved significantly. To try it out, upgrade to sbt 0.13.2 and add `incOptions := incOptions.value.withNameHashing(true)` to your build! Other build tools are also supported. More info at [this sbt issue](https://github.com/sbt/sbt/issues/1010) -- that's where most of the work happened. More features are planned, e.g. [class-based tracking](https://github.com/sbt/sbt/issues/1104).
-  * We've been optimizing the batch compiler's performance as well, and will continue to work on this during the 2.11.x cycle.
-  * Improve performance of reflection [SI-6638](https://issues.scala-lang.org/browse/SI-6638)
-* The IDE received [numerous bug fixes and improvements!](https://issues.scala-lang.org/browse/SI-8085?jql=component%20%3D%20%22Presentation%20Compiler%22%20AND%20project%20%3D%20SI%20AND%20resolution%20%3D%20fixed%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.0-M1%22%20and%20fixVersion%20%3C%3D%20%20%22Scala%202.11.2%22%20ORDER%20BY%20updated%20DESC)
-* REPL
-  * The bytecode decompiler command, :javap, now works with Java 7 [SI-4936](https://issues.scala-lang.org/browse/SI-4936) and has sprouted new options [SI-6894](https://issues.scala-lang.org/browse/SI-6894) (Thanks, [@som-snytt](https://github.com/som-snytt)!)
-  * Added command :kind to help to tell ground types from type constructors. [#2340](https://github.com/scala/scala/pull/2340) (Thanks, [George Leontiev](https://github.com/folone) and [Eugene Yokota](https://github.com/eed3si9n)!)
-  * The interpreter can now be embedded as a JSR-223 Scripting Engine [SI-874](https://issues.scala-lang.org/browse/SI-874). (Thanks, [Raphael Jolly](https://github.com/rjolly)!)
-* Improved `-Xlint` warnings
-  * Warn about unused private / local terms and types, and unused imports.
-  * This will even tell you when a local `var` could be a `val`.
-* Slimming down the compiler
-  * The experimental .NET backend has been removed from the compiler.
-  * Scala 2.10 shipped with new implementations of the Pattern Matcher and the Bytecode Emitter. We have removed the old implementations.
-  * Search and destroy mission for ~5000 chunks of dead code. [#1648](https://github.com/scala/scala/pull/1648/files)
+The release notes for the Scala 2.11 series, which also apply to the current minor release, are available in the [release notes for Scala 2.11.1](http://scala-lang.org/news/2.11.1). They contain important information such as:
 
-The Scala team and contributors [fixed 706 bugs](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20>%3D%20"Scala%202.11.0-M1"%20and%20fixVersion%20<%3D%20"Scala%202.11.2"%20and%20resolution%20%3D%20fixed) that are exclusive to Scala 2.11! We also backported as many as possible. With the release of 2.11, 2.10 backports will be dialed back.
+* The specification of binary compatibility between minor releases.
+* Details on new features, important changes and deprecations in Scala 2.11.
 
-A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, participating in mailing lists and other public fora, and -- of course -- submitting and reviewing pull requests! You are all awesome.
+### Contributors
 
-Concretely, according to `git log --no-merges --oneline 2.11.x --not 2.10.x --format='%aN'  | sort | uniq -c | sort -rn`, 120 people contributed code, tests, and/or documentation to Scala 2.11.x: Paul Phillips, Jason Zaugg, Eugene Burmako, Adriaan Moors, A. P. Marki, Simon Ochsenreither, Den Shabalin, Miguel Garcia, Denys Shabalin, James Iry, Rex Kerr, Iain McGinniss, Lukas Rytz, Grzegorz Kossakowski, Vladimir Nikolaev, Eugene Vigdorchik, François Garillot, Antoine Gourlay, Mirco Dotta, Rüdiger Klaehn, Raphael Jolly, Paolo Giarrusso, Kenji Yoshida, Hubert Plociniczak, Aleksandar Prokopec, Simon Schaefer, Lex Spoon, Jean-Remi Desjardins, Andrew Phillips, Vlad Ureche, Tobias Roeser, Sébastien Doeraene, Philipp Haller, Luc Bourlier, Josh Suereth, Chris Hodapp, Vojin Jovanovic, Viktor Klang, Valerian, Prashant Sharma, Pavel Pavlov, Michael Thorpe, Jan Niehusmann, Heejong Lee, George Leontiev, Daniel C. Sobral, Christoffer Sawicki, yllan, rjfwhite, Volkan Yazıcı, Todd Vierling, Ruslan Shevchenko, Robin Green, Olivier Blanvillain, Marcin Kubala, Johannes Rudolph, Iulian Dragos, Ilya Maykov, Eugene Yokota, Erik Osheim, Dan Hopkins, Antonio Cunei, Andriy Polishchuk, Alexander Clare, 杨博, srinivasreddy, secwall, nermin, martijnhoekstra, kurnevsky, jinfu-leng, folone, Yaroslav Klymko, Xusen Yin, Trent Ogren, Tobias Schlatter, Thomas Geier, Stuart Golodetz, Stephen Compall, Stefan Zeiger, Scott Carey, Samy Dindane, Sagie Davidovich, Runar Bjarnason, Rui Gonçalves, Roland Kuhn, Roberto Tyley, Robert Nix, Robert Ladstätter, Rike-Benjamin Schuppner, Rajiv, Nada Amin, Mike Morearty, Michael Bayne, Martin Odersky, Mark Harrah, Luke Cycon, Lee Mighdoll, Konstantin Fedorov, Julio Santos, Julien Richard-Foy, Juha Heljoranta, Jiawei Li, Jentsch, Jason Swartz, James Ward, James Roper, Havoc Pennington, Guillaume Martres, Evgeny Kotelnikov, Dmitry Petrashko, Dmitry Bushev, David Hall, Daniel Darabos, Dan Rosen, Cody Allen, Carlo Dapor, Brian McKenna, Andrey Kutejko, Alden Torres.
+A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, participating in mailing lists and other public fora, and submitting and reviewing pull requests!
+You are all awesome.
 
-Thank you all very much.
-
-If you find any errors or omissions in these relates notes, [please submit a PR](https://github.com/scala/make-release-notes/blob/2.11.x/hand-written.md)!
-
-### Reporting Bugs / Known Issues
-Please [file any bugs you encounter](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11311). If you're unsure whether something is a bug, please contact the [scala-user](https://groups.google.com/forum/?fromgroups#!forum/scala-user) mailing list.
-
-Before reporting a bug, please have a look at these [known issues](https://issues.scala-lang.org/browse/SI-6267?jql=project%20%3D%20SI%20AND%20(fixVersion%20is%20empty%20or%20fixVersion%20%3E%20%22Scala%202.11.2%22)%20AND%20affectedVersion%20in%20(%22Scala%202.11.0%22%2C%20%22Scala%202.11.1%22%2C%20%22Scala%202.11.2%22)%20%20and%20resolution%20%3D%20unresolved%20ORDER%20BY%20priority%20DESC).
-
-### Scala IDE for Eclipse
-The Scala IDE with this release built in is [available from this update site](http://download.scala-ide.org/ecosystem/helium/e38/scala211/stable/site/) for [Eclipse 4.2/4.3 (Juno/Kepler)](http://www.eclipse.org/downloads/packages/eclipse-ide-java-developers/keplersr2). Please have a look at the [getting started guide](http://scala-ide.org/docs/user/gettingstarted.html) for more info.
-
-
-### Available projects
-The following Scala projects have already been released against 2.11! See also [@jrudolph's analysis](https://gist.github.com/jrudolph/7a323f5e2820d8479b18) of the availability of 2.11 builds of popular libraries (as well as which ones are missing); updated regularly.
-
-We'd love to include your release in this list as soon as it's available -- please submit a PR to update [these release notes](https://github.com/scala/make-release-notes/blob/2.11.x/hand-written.md).
-
-    "org.scalacheck"                   %% "scalacheck"                % "1.11.4"
-    "org.scalatest"                    %% "scalatest"                 % "2.1.7"
-    "org.scalautils"                   %% "scalautils"                % "2.1.3"
-    "com.typesafe.akka"                %% "akka-actor"                % "2.3.2"
-    "com.typesafe.scala-logging"       %% "scala-logging-slf4j"       % "2.1.2"
-    "org.scala-lang.modules"           %% "scala-async"               % "0.9.1"
-    "org.scalikejdbc"                  %% "scalikejdbc-interpolation" % "2.0.0-beta1"
-    "com.softwaremill.scalamacrodebug" %% "macros"                    % "0.4"
-    "com.softwaremill.macwire"         %% "macros"                    % "0.6"
-    "com.chuusai"                      %% "shapeless"                 % "1.2.4"
-    "com.chuusai"                      %% "shapeless"                 % "2.0.0"
-    "org.nalloc"                       %% "optional"                  % "0.1.0"
-    "org.scalaz"                       %% "scalaz-core"               % "7.0.6"
-    "com.assembla.scala-incubator"     %% "graph-core"                % "1.8.1"
-    "com.nocandysw"                    %% "platform-executing"        % "0.5.0"
-    "com.qifun"                        %% "stateless-future"          % "0.1.1"
-    "com.github.scopt"                 %% "scopt"                     % "3.2.0"
-    "com.dongxiguo"                    %% "commons-continuations"     % "0.2.2"
-    "com.dongxiguo"                    %% "memcontinuationed"         % "0.3.2"
-    "com.dongxiguo"                    %% "fastring"                  % "0.2.4"
-    "com.dongxiguo"                    %% "zero-log"                  % "0.3.5"
-    "com.github.seratch"               %% "ltsv4s"                    % "1.0.0"
-    "com.googlecode.kiama"             %% "kiama"                     % "1.5.3"
-    "org.scalamock"                    %% "scalamock-scalatest-support" % "3.0.1"
-    "org.scalamock"                    %% "scalamock-specs2-support"  % "3.0.1"
-    "com.github.nscala-time"           %% "nscala-time"               % "1.0.0"
-    "com.github.xuwei-k"               %% "applybuilder70"            % "0.1.2"
-    "com.github.xuwei-k"               %% "nobox"                     % "0.1.9"
-    "org.typelevel"                    %% "scodec-bits"               % "1.0.0"
-    "org.typelevel"                    %% "scodec-core"               % "1.0.0"
-    "com.sksamuel.scrimage"            %% "scrimage"                  % "1.3.20"
-    "net.databinder"                   %% "dispatch-http"             % "0.8.10"
-    "net.databinder"                   %% "unfiltered"                % "0.8.0"
-    "net.databinder"                   %% "unfiltered"                % "0.7.1"
-    "io.argonaut"                      %% "argonaut"                  % "6.0.4"
-    "org.specs2"                       %% "specs2"                    % "2.3.12"
-    "com.propensive"                   %% "rapture-core"              % "0.9.0"
-    "com.propensive"                   %% "rapture-json"              % "0.9.1"
-    "com.propensive"                   %% "rapture-io"                % "0.9.1"
-    "org.scala-stm"                    %% "scala-stm"                 % "0.7"
-    "org.parboiled"                    %% "parboiled-scala"           % "1.1.6"
-    "io.spray"                         %% "spray-json"                % "1.2.6"
-    "org.scala-libs"                   %% "scalajpa"                  % "1.5"
-    "com.casualmiracles"               %% "treelog"                   % "1.2.3"
-    "org.monifu"                       %% "monifu"                    % "0.6.1"
-    "org.mongodb"                      %% "casbah"                    % "2.7.1"
-    "com.clarifi"                      %% "f0"                        % "1.1.2"
-    "org.scalaj"                       %% "scalaj-http"               % "0.3.15"
-
-The following libraries are specific to the 2.11.x minor release you're using. If you depend on them, you should also cross-version fully!
-
-    "org.scalamacros"                   % "paradise"                  % "2.0.0" cross CrossVersion.full
-
-### Cross-building with sbt 0.13
-When cross-building between Scala versions, you often need to vary the versions of your dependencies. In particular, the new scala modules (such as scala-xml) are no longer included in scala-library, so you'll have to add an explicit dependency on it to use Scala's xml support.
-
-Here's how we recommend handling this in sbt 0.13. For the full build and Maven build, see [example](https://github.com/scala/scala-module-dependency-sample).
-
-    scalaVersion        := "2.11.2"
-
-    crossScalaVersions  := Seq("2.11.2", "2.10.4")
-
-    // add scala-xml dependency when needed (for Scala 2.11 and newer)
-    // this mechanism supports cross-version publishing
-    libraryDependencies := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-          libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-xml" % "1.0.1"
-        case _ =>
-          libraryDependencies.value
-      }
-    }
-
-### Important changes
-For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x) a [sizeable number of open source projects](https://github.com/typesafehub/community-builds/blob/master/common-2.11.x.conf#L43). 
-
-Changes to the reflection API may cause breakages, but these breakages can be easily fixed in a manner that is source-compatible with Scala 2.10.x. Follow our reflection/macro changelog for [detailed instructions](http://docs.scala-lang.org/overviews/macros/changelog211.html#how_to_make_your_210x_macros_work_in_2110).
-
-We've decided to fix the following more obscure deviations from specified behavior without deprecating them first.
-
-* [SI-4577](https://issues.scala-lang.org/browse/SI-4577) Compile `x match { case _ : Foo.type => }` to `Foo eq x`, as specified. It used to be `Foo == x` (without warning). If that's what you meant, write `case Foo =>`.
-* [SI-7475](https://issues.scala-lang.org/browse/SI-7475) Improvements to access checks, aligned with the spec (see also the linked issues). Most importantly, private members are no longer inherited. Thus, this does not type check: `class Foo[T] { private val bar: T = ???; new Foo[String] { bar: String } }`, as the `bar` in `bar: String` refers to the `bar` with type `T`. The `Foo[String]`'s `bar` is not inherited, and thus not in scope, in the refinement. (Example from [SI-8371](https://issues.scala-lang.org/browse/SI-8371), see also [SI-8426](https://issues.scala-lang.org/browse/SI-8426).)
-
-The following changes were made after a deprecation cycle (Thank you, [@soc](https://github.com/soc), for leading the deprecation effort!)
-
-* [SI-6809](https://issues.scala-lang.org/browse/SI-6809) Case classes without a parameter list are no longer allowed.
-* [SI-7618](https://issues.scala-lang.org/browse/SI-7618) Octal number literals no longer supported.
-
-Finally, some notable improvements and bug fixes:
-
-* [SI-8549](https://issues.scala-lang.org/browse/SI-8549) Fix bad regression: no `serialVersionUID` field for classes annotated with [@SerialVersionUID](http://www.scala-lang.org/api/2.11.2/index.html#scala.SerialVersionUID). The Scala standard library itself was a victim of this bug. As such, collections serialized in 2.11.0 will not be able to be deserialized in 2.11.1. This regression occurred in a failed [attempt](https://github.com/scala/scala/pull/1673) to fix a related bug in 2.10.x, [SI-6988](https://issues.scala-lang.org/browse/SI-6988), whereby classes annotated with non literal UIDS, e.g. `0L - 123L`, had no field generated. 
-* [SI-7296](https://issues.scala-lang.org/browse/SI-7296) Case classes with > 22 parameters are now allowed.
-* [SI-3346](https://issues.scala-lang.org/browse/SI-3346) Implicit arguments of implicit conversions now guide type inference.
-* [SI-6240](https://issues.scala-lang.org/browse/SI-6240) Thread safety of reflection API.
-* [#3037](https://github.com/scala/scala/pull/3037) Experimental support for SAM synthesis.
-* [#2848](https://github.com/scala/scala/pull/2848) Name-based pattern-matching.
-* [SI-6169](https://issues.scala-lang.org/browse/SI-6169) Infer bounds of Java-defined existential types.
-* [SI-6566](https://issues.scala-lang.org/browse/SI-6566) Right-hand sides of type aliases are now considered invariant for variance checking.
-* [SI-5917](https://issues.scala-lang.org/browse/SI-5917) Improve public AST creation facilities.
-* [SI-8063](https://issues.scala-lang.org/browse/SI-8063) Expose much needed methods in public reflection/macro API.
-* [SI-8126](https://issues.scala-lang.org/browse/SI-8126) Add -Xsource option (make 2.11 type checker behave like 2.10 where possible).
-* [SI-8157](https://issues.scala-lang.org/browse/SI-8157) Polymorphic methods also subject to restriction: only one overload may define default arguments
-
-To catch future changes like this early, you can run the compiler under -Xfuture, which makes it behave like the next major version, where possible, to alert you to upcoming breaking changes.
-
-### Deprecations
-Deprecation is essential to two of the 2.11.x series' three themes ([faster/smaller/stabler](http://java.dzone.com/articles/state-scala-2013)). They make the language and the libraries smaller, and thus easier to use and maintain, which ultimately improves stability. We are very proud of Scala's first decade, which brought us to where we are, and we are actively working on minimizing the downsides of this legacy, as exemplified by 2.11.x's focus on deprecation, modularization and infrastructure work.
-
-The following language "warts" have been deprecated:
-
-* [SI-7605](https://issues.scala-lang.org/browse/SI-7605) Procedure syntax (only under -Xfuture).
-* [SI-5479](https://issues.scala-lang.org/browse/SI-5479) DelayedInit. We will continue support for the important `extends App` idiom. We won't drop `DelayedInit` until there's a replacement for important use cases. ([More details and a proposed alternative.](https://issues.scala-lang.org/browse/SI-4330?jql=labels%20%3D%20delayedinit%20AND%20resolution%20%3D%20unresolved))
-* [SI-6455](https://issues.scala-lang.org/browse/SI-6455) Rewrite of `.withFilter` to `.filter`: you must implement `withFilter` to be compatible with for-comprehensions.
-* [SI-8035](https://issues.scala-lang.org/browse/SI-8035) Automatic insertion of `()` on missing argument lists.
-* [SI-6675](https://issues.scala-lang.org/browse/SI-6675) Auto-tupling in patterns.
-* [SI-7247](https://issues.scala-lang.org/browse/SI-7247) NotNull, which was never fully implemented -- slated for removal in 2.12.
-* [SI-1503](https://issues.scala-lang.org/browse/SI-1503) Unsound type assumption for stable identifier and literal patterns.
-* [SI-7629](https://issues.scala-lang.org/browse/SI-7629) View bounds (*under -Xfuture*).
-
-We'd like to emphasize the following library deprecations:
-
-* [#3103](https://github.com/scala/scala/pull/3103), [#3191](https://github.com/scala/scala/pull/3191), [#3582](https://github.com/scala/scala/pull/3582) Collection classes and methods that are (very) difficult to extend safely have been slated for being marked `final`. Proxies and wrappers that were not adequately implemented or kept up-to-date have been deprecated, along with other minor inconsistencies.
-* scala-actors is now deprecated and will be removed in 2.12; please follow the steps in the [Actors Migration Guide](http://docs.scala-lang.org/overviews/core/actors-migration-guide.html) to port to Akka Actors
-* [SI-7958](https://issues.scala-lang.org/browse/SI-7958) Deprecate `scala.concurrent.future` and `scala.concurrent.promise`
-* [SI-3235](https://issues.scala-lang.org/browse/SI-3235) Deprecate `round` on `Int` and `Long` ([#3581](https://github.com/scala/scala/pull/3581)).
-* We are looking for maintainers to take over the following modules: [scala-swing](https://github.com/scala/scala-swing), [scala-continuations](https://github.com/scala/scala-continuations). 2.12 will not include them if no new maintainer is found.
-  We will likely keep maintaining the other modules (scala-xml, scala-parser-combinators), but help is still greatly appreciated.
-  
-Deprecation is closely linked to source and binary compatibility. We say two versions are source compatible when they compile the same programs with the same results. Deprecation requires qualifying this statement: "assuming there are no deprecation warnings". This is what allows us to evolve the Scala platform and keep it healthy. We move slowly to guarantee smooth upgrades, but we want to keep improving as well!
-
-### Binary Compatibility
-When two versions of Scala are binary compatible, it is safe to compile your project on one Scala version and link against another Scala version at run time. Safe run-time linkage (only!) means that the JVM does not throw a (subclass of) [`LinkageError`](http://docs.oracle.com/javase/7/docs/api/java/lang/LinkageError.html) when executing your program in the mixed scenario, assuming that none arise when compiling and running on the same version of Scala. Concretely, this means you may have external dependencies on your run-time classpath that use a different version of Scala than the one you're compiling with, as long as they're binary compatibile. In other words, separate compilation on different binary compatible versions does not introduce problems compared to compiling and running everything on the same version of Scala.
-
-We check binary compatibility automatically with [MiMa](https://github.com/typesafehub/migration-manager). We strive to maintain a similar invariant for the `behavior` (as opposed to just linkage) of the standard library, but this is not checked mechanically (Scala is not a proof assistant so this is out of reach for its type system).
-
-#### Forwards and Back
-We distinguish forwards and backwards compatibility (think of these as properties of a sequence of versions, not of an individual version). Maintaining backwards compatibility means code compiled on an older version will link with code compiled with newer ones. Forwards compatibility allows you to compile on new versions and run on older ones.
-
-Thus, backwards compatibility precludes the removal of (non-private) methods, as older versions could call them, not knowing they would be removed, whereas forwards compatibility disallows adding new (non-private) methods, because newer programs may come to depend on them, which would prevent them from running on older versions (private methods are exempted here as well, as their definition and call sites must be in the same compilation unit).
-
-These are strict constraints, but they have worked well for us in the Scala 2.10.x series. They didn't stop us from fixing [372 issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20"SI"%20AND%20resolution%3D"fixed"%20and%20fixVersion%20>%20"Scala%202.10.0"%20and%20fixVersion%20<%3D%20"Scala%202.10.4") in the 2.10.x series post 2.10.0. The advantages are clear, so we will maintain this policy in the 2.11.x series, and are looking (but not yet commiting!) to extend it to include major versions in the future.
-
-#### Meta
-Note that so far we've only talked about the jars generated by scalac for the standard library and reflection.
-Our policies do not extend to the meta-issue: ensuring binary compatibility for bytecode generated from identical sources, by different version of scalac? (The same problem exists for compiling on different JDKs.) While we strive to achieve this, it's not something we can test in general. Notable examples where we know meta-binary compatibility is hard to achieve: specialisation and the optimizer.
-
-In short, if binary compatibility of your library is important to you, use [MiMa](https://github.com/typesafehub/migration-manager) to verify compatibility before releasing.
-Compiling identical sources with different versions of the scala compiler (or on different JVM versions!) could result in binary incompatible bytecode. This is rare, and we try to avoid it, but we can't guarantee it will never happen.
-
-#### Concretely
-Just like the 2.10.x series, we guarantee forwards and backwards compatibility of the `"org.scala-lang" % "scala-library" % "2.11.x"` and `"org.scala-lang" % "scala-reflect" % "2.11.x"` artifacts, except for anything under the `scala.reflect.internal` package, as scala-reflect is still experimental. We also strongly discourage relying on the stability of `scala.concurrent.impl` and `scala.reflect.runtime`, though we will only break compatibility for severe bugs here.
-
-Note that we will only enforce *backwards* binary compatibility for the new modules (artifacts under the groupId `org.scala-lang.modules`). As they are opt-in, it's less of a burden to require having the latest version on the classpath. (Without forward compatibility, the latest version of the artifact must be on the run-time classpath to avoid linkage errors.)
-
-Finally, Scala 2.11 introduces `scala-library-all` to aggregate the modules that constitute a Scala release. Note that this means it does not provide forward binary compatibility, whereas the core `scala-library` artifact does. We consider the versions of the modules that `"scala-library-all" % "2.11.x"` depends on to be the canonical ones, that are part of the official Scala distribution. (The distribution itself is defined by the new `scala-dist` maven artifact.)
-
-### License clarification
-Scala is now distributed under the standard 3-clause BSD license. Originally, the same 3-clause BSD license was adopted, but slightly reworded over the years, and the "Scala License" was born. We're now back to the standard formulation to avoid confusion.
+According to `git log --no-merges --oneline v2.11.2 --not v2.11.1 --format='%aN' | sort | uniq -c | sort -rn`, 21 people contributed code to this minor release:
+Jason Zaugg, A. P. Marki, Lukas Rytz, Adriaan Moors, Rex Kerr, Eugene Burmako, Antoine Gourlay, Tobias Roeser, Philipp Haller, Denys Shabalin, Todd Vierling, Chris Hodapp, Vladimir Nikolaev, Stephen Compall, Rui Gonçalves, Paolo Giarrusso, Martin Odersky, Marcin Kubala, Johannes Rudolph, Jean-Remi Desjardins, François Garillot.

--- a/hand-written.md
+++ b/hand-written.md
@@ -19,7 +19,7 @@ This release fixes [26 issues](https://issues.scala-lang.org/browse/SI-8549?jql=
 The next minor Scala 2.11 release will be available in at most 2 months, or sooner if prompted by a serious issue.
 
 ### Upgrading
-Code that compiled on 2.10.x without deprecation warnings should compile on 2.11.x (we do not guarantee this for experimental APIs, such as reflection). If not, [please file a regression](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11311&labels=regression). We are working with the community to ensure availability of the core projects of the Scala 2.11.x eco-system, please see below for a list. This release is *not* binary compatible with the 2.10.x series, to allow us to keep improving the Scala standard library.
+Code that compiled on 2.10.x without deprecation warnings should compile on 2.11.x (we do not guarantee this for experimental APIs, such as reflection). If not, [please file a regression](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11808&labels=regression). We are working with the community to ensure availability of the core projects of the Scala 2.11.x eco-system, please see below for a list. This release is *not* binary compatible with the 2.10.x series, to allow us to keep improving the Scala standard library.
 
 ### Required Java Version
 The Scala 2.11.x series targets Java 6, with (evolving) experimental support for Java 8. In 2.11.1, Java 8 support is mostly limited to reading Java 8 bytecode and parsing Java 8 source. Stay tuned for more complete (experimental) Java 8 support. The next major release, 2.12, will most likely target Java 8 by default.

--- a/hand-written.md
+++ b/hand-written.md
@@ -1,100 +1,52 @@
-<!---
-NOTE: Our generator now strips triple-dash comments form the generated markdown.
-      These have been problematic for jekyll.
--->
+We are very pleased to announce the release of Scala 2.12.0-M1!
 
-We are very pleased to announce the final release of Scala 2.11.0!
-
-<!-- Notes from 2.11.0
+<!-- To be added:
 * Get started with the [Hello Scala 2.11 template](https://typesafe.com/activator/template/hello-scala-2_11) in [Typesafe Activator](https://typesafe.com/platform/getstarted)
-* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.0.html)
-* Obtain it via [Maven Central](http://search.maven.org/?search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.0%22#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.0%22)
-
-There have been no code changes since RC4, just improvements to documentation and version bump to the most recent stable version of Akka actors. Here's the [difference between the release and RC4](https://github.com/scala/scala/compare/v2.11.0-RC4...v2.11.0).
-
-Code that compiled on 2.10.x without deprecation warnings should compile on 2.11.x (we do not guarantee this for experimental APIs, such as reflection). If not, [please file a regression](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11311&labels=regression). We are working with the community to ensure availability of the core projects of the Scala 2.11.x eco-system, please see below for a list. This release is *not* binary compatible with the 2.10.x series, to allow us to keep improving the Scala standard library.
 -->
 
-<!--break-->
+* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.12.0-M1.html)
+* Obtain it via [Maven Central](http://search.maven.org/?search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.0%22#search%7Cga%7C1%7Cg%3Aorg.scala-lang%20AND%20v%3A2.12.0-M1)
+
+Code that compiles on 2.11.x without deprecation warnings should compile on 2.12.x (we do not guarantee this for experimental APIs, such as reflection).
+If not, [please file an issue](https://issues.scala-lang.org).
+
+We are working with the community to ensure availability of the core projects of the Scala 2.12 eco-system.
+This release is *not* binary compatible with the 2.11.x series, to allow us to keep improving the Scala standard library.
+
+The Scala 2.12 series targets Java 8.
+Programs written in Scala 2.12, including the Scala 2.12 compiler, can only be executed on Java 8 or newer.
+Note that the current milestone release (2.12.0-M1) still targets Java 6.
+
+
+### New Features in the 2.12 Series
+
+Scala 2.12 contains all of the bug fixes and improvements made in the 2.11 series.
+
+At the current stage in the milestone cycle, Scala 2.12 is still very similar to Scala 2.11.
+
+The following changes are planned for Scala 2.12:
+  * Java 8 style closures.
+    The Scala compiler will emit closure classes (lambdas) in the same manner as Java 8.
+    The design notes for this feature are available in [this gist](https://gist.github.com/retronym/0178c212e4bacffed568).
+  * Lambda syntax for SAM types.
+    Similar to Java 8, Scala 2.12 allows instantiating any type with one single abstract method by passing a lambda.
+    This feature is already avalable in Scala 2.11 using the `-Xexperimental` compiler option.
+    It improves the experience of using libraries written for Java 8 in Scala.
+  * New backend and optimizer.
+    The "GenBCode" backend, which is already available in Scala 2.11 using the `-Ybackend:GenBCode` compiler option, will be enabled by default.
+    Scala 2.12 will also ship with a new inliner and bytecode optimizer.
+    We keep track of issues and work items for the new optimizer on the [scala-opt repostiory issue tracker](https://github.com/scala-opt/scala/issues).
+
+The above list is incomplete and will be extendend during the Scala 2.12 milestone cycle.
+
+Up the current milestone, the Scala team and contributors [fixed 47 bugs](https://issues.scala-lang.org/browse/SI-9200?jql=project%20%3D%20SI%20and%20fixVersion%20%3E%3D%20%222.12.0-M1%22%20and%20fixVersion%20%3C%3D%20%222.12.0%22%20and%20resolution%20%3D%20fixed) that are exclusive to Scala 2.12.0.
+During the development cycle of Scala 2.12, we will continue to backport issues to 2.11 whenever feasible.
+With the release of 2.12.0, backports to 2.11 will be dialed back.
+
 
 <!-- Notes from 2.11.0
-The Scala 2.11.x series targets Java 6, with (evolving) experimental support for Java 8. In 2.11.0, Java 8 support is mostly limited to reading Java 8 bytecode and parsing Java 8 source. Stay tuned for more complete (experimental) Java 8 support.
--->
+#### Important Changes
 
-### New features in the 2.12 series
-This release contains all of the bug fixes and improvements made in the 2.11 series, as well as:
-
-<!-- Notes from 2.11.0
-* Collections
-  * Immutable `HashMap`s and `HashSet`s perform faster filters, unions, and the like, with improved structural sharing (lower memory usage or churn).
-  * ...
--->
-
-<!-- Notes from 2.11.0
-The Scala team and contributors [fixed 613 bugs](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20>%3D%20"Scala%202.11.0-M1"%20and%20fixVersion%20<%3D%20"Scala%202.11.0"%20and%20resolution%20%3D%20fixed) that are exclusive to Scala 2.11.0! We also backported as many as possible. With the release of 2.11, 2.10 backports will be dialed back.
-
-A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, participating in mailing lists and other public fora, and -- of course -- submitting and reviewing pull requests! You are all awesome.
-
-Concretely, according to `git log --no-merges --oneline master --not 2.10.x --format='%aN'  | sort | uniq -c | sort -rn`, 112 people contributed code, tests, and/or documentation to Scala 2.11.x: Paul Phillips, Jason Zaugg, ...
-
-Thank you all very much.
-
-If you find any errors or omissions in these relates notes, [please submit a PR](https://github.com/scala/make-release-notes/blob/master/hand-written.md)!
--->
-
-<!-- Notes from 2.11.0
-### Reporting Bugs / Known Issues
-Please [file any bugs you encounter](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11311). If you're unsure whether something is a bug, please contact the [scala-user](https://groups.google.com/forum/?fromgroups#!forum/scala-user) mailing list.
-
-Before reporting a bug, please have a look at these [known issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20fixVersion%20%21%3D%20%22Scala%202.11.0-RC3%22%20AND%20affectedVersion%20%3D%20%22Scala%202.11.0%22%20%20and%20resolution%20%3D%20unresolved%20ORDER%20BY%20priority%20DESC).
--->
-
-### Scala IDE for Eclipse
-
-<!-- Notes from 2.11.0
-The Scala IDE with this release built in is [available from this update site](http://download.scala-ide.org/sdk/helium/e38/scala211/stable/site/) for [Eclipse 4.2/4.3 (Juno/Kepler)](http://www.eclipse.org/downloads/packages/eclipse-ide-java-developers/keplersr2). Please have a look at the [getting started guide](http://scala-ide.org/docs/user/gettingstarted.html) for more info.
--->
-
-### Available projects
-
-<!-- Notes from 2.11.0
-The following Scala projects have already been released against 2.11.0! We'd love to include yours in this list as soon as it's available -- please submit a PR to update [these release notes](https://github.com/scala/make-release-notes/blob/master/hand-written.md).
-
-    "org.scalacheck"                   %% "scalacheck"                % "1.11.3"
-    ...
-
-The following projects were released against 2.11.0-RC4, with an 2.11 build hopefully following soon:
-
-    "org.scalafx"            %% "scalafx"            % "8.0.0-R4"
-    ...
--->
-
-### Cross-building with sbt 0.13
-
-<!-- Notes from 2.11.0
-When cross-building between Scala versions, you often need to vary the versions of your dependencies. In particular, the new scala modules (such as scala-xml) are no longer included in scala-library, so you'll have to add an explicit dependency on it to use Scala's xml support.
-
-Here's how we recommend handling this in sbt 0.13. For the full build and Maven build, see [example](https://github.com/scala/scala-module-dependency-sample).
-
-    scalaVersion        := "2.11.0"
-
-    crossScalaVersions  := Seq("2.11.0", "2.10.3")
-
-    // add scala-xml dependency when needed (for Scala 2.11 and newer)
-    // this mechanism supports cross-version publishing
-    libraryDependencies := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-          libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-xml" % "1.0.1"
-        case _ =>
-          libraryDependencies.value
-      }
-    }
--->
-
-### Important changes
-
-<!-- Notes from 2.11.0
 For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x) a [sizeable number of open source projects](https://github.com/typesafehub/community-builds/blob/master/common-2.11.x.conf#L43).
 
 Changes to the reflection API may cause breakages...
@@ -113,43 +65,93 @@ Finally, some notable improvements and bug fixes:
 
 * [SI-7296](https://issues.scala-lang.org/browse/SI-7296) Case classes with > 22 parameters are now allowed.
 *...
--->
 
-### Deprecations
+
+#### Deprecations
 
 The following language "warts" have been deprecated:
 * [#3746](https://github.com/scala/scala/pull/3746) Generation of bean info classes using the `@BeanInfo` annotation.
-
-<!-- Notes from 2.11.0
 Deprecation is closely linked to source and binary compatibility. We say two versions are source compatible when they compile the same programs with the same results. Deprecation requires qualifying this statement: "assuming there are no deprecation warnings". This is what allows us to evolve the Scala platform and keep it healthy. We move slowly to guarantee smooth upgrades, but we want to keep improving as well!
 -->
 
-### Binary Compatibility
 
-When two versions of Scala are binary compatible, it is safe to compile your project on one Scala version and link against another Scala version at run time. Safe run-time linkage (only!) means that the JVM does not throw a (subclass of) [`LinkageError`](http://docs.oracle.com/javase/7/docs/api/java/lang/LinkageError.html) when executing your program in the mixed scenario, assuming that none arise when compiling and running on the same version of Scala. Concretely, this means you may have external dependencies on your run-time classpath that use a different version of Scala than the one you're compiling with, as long as they're binary compatibile. In other words, separate compilation on different binary compatible versions does not introduce problems compared to compiling and running everything on the same version of Scala.
+#### Removed Modules
 
-We check binary compatibility automatically with [MiMa](https://github.com/typesafehub/migration-manager). We strive to maintain a similar invariant for the `behavior` (as opposed to just linkage) of the standard library, but this is not checked mechanically (Scala is not a proof assistant so this is out of reach for its type system).
+The following modules have been removed from the Scala 2.12 distribution:
+  * The Scala actors library is no longer released with Scala 2.12.
+    We recommend that you use the [Akka actors library](http://akka.io/) instead.
+    To migrate your code, follow the [Scala actors migration guide](http://docs.scala-lang.org/overviews/core/actors-migration-guide.html) before upgrading your project to Scala 2.12.
+  * The Scala distribution archives and the `scala-library-all` maven dependency no longer inlcude Akka actors.
+    To use the Akka actors library, add it to your project [as a dependency](http://doc.akka.io/docs/akka/2.3.10/intro/getting-started.html).
+  * The continuations plugin is no longer shipped with the Scala 2.12 distribution.
 
-#### Forwards and Back
-We distinguish forwards and backwards compatibility (think of these as properties of a sequence of versions, not of an individual version). Maintaining backwards compatibility means code compiled on an older version will link with code compiled with newer ones. Forwards compatibility allows you to compile on new versions and run on older ones.
 
-Thus, backwards compatibility precludes the removal of (non-private) methods, as older versions could call them, not knowing they would be removed, whereas forwards compatibility disallows adding new (non-private) methods, because newer programs may come to depend on them, which would prevent them from running on older versions (private methods are exempted here as well, as their definition and call sites must be in the same compilation unit).
+#### Contributors
+
+A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, spreading kindness in mailing lists and other public fora, and submitting and reviewing pull requests!
+You are all magnificent.
+
+According to `git shortlog -sn --no-merges 2.11.x..v2.12.0-M1`, 33 people contributed to this major release:
+Jason Zaugg, Lukas Rytz, A. P. Marki, Rex Kerr, Kato Kazuyoshi, Max Bileschi, jxcoder, François Garillot, rubyu, Adriaan Moors, Dominik Gruntz, Evgeny Vereshchagin, Marc Siegel, Masato Sogame, Simon Ochsenreither, Todd Vierling, Viktor Klang, cchantep, Denton Cockburn, Paolo Giarrusso, Denis Rosset, Roman Hargrave, Rui Gonçalves, Shadaj, harryhuk, Steven Scott, Antoine Gourlay, Aleksandar Prokopec, Lukas Elmer, Erlend Hamnaberg, Maks Atygaev, Malte Isberner, dgruntz.
+Thank you!
+
+These release notes are [hosted on GitHub](https://github.com/scala/make-release-notes/blob/2.12.x/hand-written.md) and are continuously updated during the Scala 2.12.0 release cycle.
+You are kindly invited to contribute!
+
+
+### Reporting Bugs
+
+Please file any bugs you encounter on [our issue tracker](https://issues.scala-lang.org).
+If you're unsure whether something is a bug, please contact the [scala-user](https://groups.google.com/forum/?fromgroups#!forum/scala-user) mailing list.
+Before creating a new issue, search search the issue tracker to see if your bug has already been reported.
+
+
+### Scala IDE for Eclipse
+
+A release of the Scala IDE for Eclipse for Scala 2.12 will be available together with the release.
+
+Note that for the current milestone (2.12.0-M1), the Scala IDE is not yet available.
 
 <!-- Notes from 2.11.0
-These are strict constraints, but they have worked well for us in the Scala 2.10.x series. They didn't stop us from fixing [372 issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20"SI"%20AND%20resolution%3D"fixed"%20and%20fixVersion%20>%20"Scala%202.10.0"%20and%20fixVersion%20<%3D%20"Scala%202.10.4") in the 2.10.x series post 2.10.0. The advantages are clear, so we will maintain this policy in the 2.11.x series, and are looking (but not yet commiting!) to extend it to include major versions in the future.
+The Scala IDE with this release built in is [available from this update site](http://download.scala-ide.org/sdk/helium/e38/scala211/stable/site/) for [Eclipse 4.2/4.3 (Juno/Kepler)](http://www.eclipse.org/downloads/packages/eclipse-ide-java-developers/keplersr2). Please have a look at the [getting started guide](http://scala-ide.org/docs/user/gettingstarted.html) for more info.
+-->
+
+
+### Available Projects
+
+Please refer to the list of [libraries and frameworks available for Scala 2.12](https://github.com/scala/make-release-notes/blob/2.12.x/projects-2.12.md).
+
+
+### Binary Compatibility
+
+When two versions of Scala are binary compatible, it is safe to compile your project on one Scala version and link against another Scala version at run time.
+Safe run-time linkage (only!) means that the JVM does not throw a (subclass of) [`LinkageError`](http://docs.oracle.com/javase/7/docs/api/java/lang/LinkageError.html) when executing your program in the mixed scenario, assuming that none arise when compiling and running on the same version of Scala.
+Concretely, this means you may have external dependencies on your run-time classpath that use a different version of Scala than the one you're compiling with, as long as they're binary compatibile.
+In other words, separate compilation on different binary compatible versions does not introduce problems compared to compiling and running everything on the same version of Scala.
+
+We check binary compatibility automatically with [MiMa](https://github.com/typesafehub/migration-manager).
+
+#### Forwards and Back
+
+We distinguish forwards and backwards compatibility (think of these as properties of a sequence of versions, not of an individual version).
+Maintaining backwards compatibility means code compiled on an older version will link with code compiled with newer ones.
+Forwards compatibility allows you to compile on new versions and run on older ones.
+
+Thus, backwards compatibility precludes the removal of (non-private) methods, as older versions could call them, not knowing they would be removed, whereas forwards compatibility disallows adding new (non-private) methods, because newer programs may come to depend on them, which would prevent them from running on older versions (private methods are exempted here as well, as their definition and call sites must be in the same compilation unit).
 
 #### Meta
 
 Note that so far we've only talked about the jars generated by scalac for the standard library and reflection.
-Our policies do not extend to the meta-issue: ensuring binary compatibility for bytecode generated from identical sources, by different version of scalac? (The same problem exists for compiling on different JDKs.) While we strive to achieve this, it's not something we can test in general. Notable examples where we know meta-binary compatibility is hard to achieve: specialisation and the optimizer.
+Our policies do not extend to the meta-issue: ensuring binary compatibility for bytecode generated from identical sources, by different version of scalac?
+(The same problem exists for compiling on different JDKs.)
+While we strive to achieve this, it's not something we can test in general.
+Notable examples where we know meta-binary compatibility is hard to achieve: specialisation and the optimizer.
 
 In short, if binary compatibility of your library is important to you, use [MiMa](https://github.com/typesafehub/migration-manager) to verify compatibility before releasing.
-Compiling identical sources with different versions of the scala compiler (or on different JVM versions!) could result in binary incompatible bytecode. This is rare, and we try to avoid it, but we can't guarantee it will never happen.
+Compiling identical sources with different versions of the Scala compiler (or on different JVM versions!) could result in binary incompatible bytecode.
+This is rare, and we try to avoid it, but we can't guarantee it will never happen.
 
 #### Concretely
-Just like the 2.10.x series, we guarantee forwards and backwards compatibility of the `"org.scala-lang" % "scala-library" % "2.11.x"` and `"org.scala-lang" % "scala-reflect" % "2.11.x"` artifacts, except for anything under the `scala.reflect.internal` package, as scala-reflect is still experimental. We also strongly discourage relying on the stability of `scala.concurrent.impl` and `scala.reflect.runtime`, though we will only break compatibility for severe bugs here.
 
-Note that we will only enforce *backwards* binary compatibility for the new modules (artifacts under the groupId `org.scala-lang.modules`). As they are opt-in, it's less of a burden to require having the latest version on the classpath. (Without forward compatibility, the latest version of the artifact must be on the run-time classpath to avoid linkage errors.)
-
-Finally, Scala 2.11.0 introduces `scala-library-all` to aggregate the modules that constitute a Scala release. Note that this means it does not provide forward binary compatibility, whereas the core `scala-library` artifact does. We consider the versions of the modules that `"scala-library-all" % "2.11.x"` depends on to be the canonical ones, that are part of the official Scala distribution. (The distribution itself is defined by the new `scala-dist` maven artifact.)
--->
+We guarantee forwards and backwards compatibility of the `"org.scala-lang" % "scala-library" % "2.12.x"` and `"org.scala-lang" % "scala-reflect" % "2.12.x"` artifacts, except for anything under the `scala.reflect.internal` package, as scala-reflect is still experimental.
+We also strongly discourage relying on the stability of `scala.concurrent.impl` and `scala.reflect.runtime`, though we will only break compatibility for severe bugs here.

--- a/hand-written.md
+++ b/hand-written.md
@@ -14,7 +14,7 @@ Scala 2.11.5 is a bugfix release that is binary compatible with previous release
 
 Compared to 2.11.4, this release resolves [74 issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20in%20%28%22Scala%202.11.5%22%29%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC). Out of 132, we [merged 110 pull requests](https://github.com/scala/scala/pulls?q=is%3Apr+is%3Amerged+milestone%3A2.11.5). Before upgrading, please also check the [known issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20status%3Dopen%20AND%20affectedVersion%20%3D%20%22Scala%202.11.5%22%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.5%22%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC) for this release.
 
-The next minor Scala 2.11 release will be available before the end of the year, or sooner if prompted by a serious issue.
+In 2015, 2.11 minor releases will be released quarterly, or sooner if prompted by a serious issue.
 
 ### Scala IDE
 The current release of Scala IDE includes Scala 2.11.5 is available on the [download site](http://scala-ide.org/download/sdk.html) (or as an update to version 4.0 of the plugin).

--- a/hand-written.md
+++ b/hand-written.md
@@ -1,30 +1,28 @@
-We are very pleased to announce the release of Scala 2.11.5!
+We are very pleased to announce the availability of Scala 2.11.6!
 
 * Get started with the [Hello Scala 2.11 template](https://typesafe.com/activator/template/hello-scala-2_11) in [Typesafe Activator](https://typesafe.com/platform/getstarted)
-* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.5.html)
-* Obtain it via [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.5%22)
+* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.6.html)
+* Obtain it via [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.6%22)
 
-Scala 2.11.5 is a bugfix release that is binary compatible with previous releases in the Scala 2.11 series. We would like to highlight the following changes:
+Scala 2.11.6 is a bugfix release that is binary compatible with previous releases in the Scala 2.11 series. We would like to highlight the following changes:
 
- - @heathermiller's [SI-6502 Reenables loading jars into the running REPL](https://github.com/scala/scala/pull/4051)
- - @mpociecha's [The alternative, flat representation of classpath elements](https://github.com/scala/scala/pull/4176)
- - @gbasler's [Avoid the 'CNF budget exceeded' exception via smarter translation into CNF](https://github.com/scala/scala/pull/4078)
- - @adriaanm's [SAMmy: eta-expansion, overloading, existentials](https://github.com/scala/scala/pull/4101)
- - A great number of documentation improvements -- thank you (and, to those appearing for the first time in our release notes, welcome!): @kanielc, @lymia, @stevegury, @vigdorchik, @gourlaysama, @ichoran, @retronym, @xuwei-k, @dickwall, @phaller.
+ - We [fixed a cross-site scripting vulnerability](https://github.com/scala/scala/pull/4350) in Scaladoc's JavaScript. Many thanks to @todesking for discovering this, suggesting a fix, and for delaying disclosure until this release! This bug could be used to access sensitive information on sites hosted on the same domain as Scaladoc-generated documentation. All previous versions of Scaladoc are affected (Scala 2.10.5 includes the fix as well). We do recommend, as a general precaution, to host Scaladoc documentation on its own domain.
+ - [SI-9089](https://issues.scala-lang.org/browse/SI-9089) repl is now much less crash-and-burny when calling a function (which turns out to be a common thing people do in a REPL). Also, apologies to the author of [SI-9022](https://issues.scala-lang.org/browse/SI-9022), who [reported this before the bug was discovered and you had to wait in line for like three hours on a Tuesday afternoon](https://issues.scala-lang.org/browse/SI-9022#comment-71996). Or, maybe, that honor should go to the enigmatic [dk14](http://stackoverflow.com/questions/27213616/why-specialized-annotation-doesnt-work-for-asinstanceof/27221875).
+ - [SI-8759](https://issues.scala-lang.org/browse/SI-8759) no need to enter almost half the konami code to enter a right square bracket in the REPL (via [jline 2.12.1](https://github.com/jline/jline2/pull/175)). Thank you for implementing the jline fix, @michael72, and kudos to @jdillon and @trptcolin for cutting a new jline release just for us!
 
-Compared to 2.11.4, this release resolves [74 issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20in%20%28%22Scala%202.11.5%22%29%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC). Out of 132, we [merged 110 pull requests](https://github.com/scala/scala/pulls?q=is%3Apr+is%3Amerged+milestone%3A2.11.5). Before upgrading, please also check the [known issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20status%3Dopen%20AND%20affectedVersion%20%3D%20%22Scala%202.11.5%22%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.5%22%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC) for this release.
+Compared to 2.11.5, this release resolves [38 issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20in%20%28%22Scala%202.11.6%22%29%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC). Out of 100, we [merged 58 pull requests](https://github.com/scala/scala/pulls?q=is%3Apr+is%3Amerged+milestone%3A2.11.6). Before upgrading, please also check the [known issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20status%3Dopen%20AND%20affectedVersion%20%3D%20%22Scala%202.11.6%22%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.6%22%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC) for this release.
 
 In 2015, 2.11 minor releases will be released quarterly, or sooner if prompted by a serious issue.
 
 ### Scala IDE
-The current release of Scala IDE includes Scala 2.11.5 is available on the [download site](http://scala-ide.org/download/sdk.html) (or as an update to version 4.0 of the plugin).
+The current release of Scala IDE includes Scala 2.11.6 is available on the [download site](http://scala-ide.org/download/sdk.html) (or as an update to version 4.0 of the plugin).
 
 ### Available Libraries and Frameworks
 
 A large number of Scala projects have been released against Scala 2.11. Please refer to the list of [libraries and frameworks available for Scala 2.11](https://github.com/scala/make-release-notes/blob/2.11.x/projects-2.11.md).
 
 ### Reminder: Do Not Use Scala 2.11.3
-Due to a [binary incompatibility](https://issues.scala-lang.org/browse/SI-8899) in Scala 2.11.3, we recommend upgrading to Scala 2.11.5, which resolves the incompatibility, as well as another [blocker issue](https://issues.scala-lang.org/browse/SI-8900) that was discovered in the days after the 2.11.3 release.
+Due to a [binary incompatibility](https://issues.scala-lang.org/browse/SI-8899) in Scala 2.11.3, we recommend upgrading to Scala 2.11.6, which resolves the incompatibility, as well as another [blocker issue](https://issues.scala-lang.org/browse/SI-8900) that was discovered in the days after the 2.11.3 release.
 
 We have [analyzed](https://groups.google.com/d/msg/scala-internals/SSD9BNJaFbU/rACBkHrs2JEJ) the mistakes that lead to the breakage (human error), and are taking measures to prevent this from happening again. We apologize for the inconvenience, and thank everyone who was involved in reporting and diagnosing these critical issues.
 
@@ -37,7 +35,7 @@ The release notes for the Scala 2.11 series, which also apply to the current min
 
 ### Contributors
 
-A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, participating in mailing lists and other public fora, and submitting and reviewing pull requests! You are all awesome.
+A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, spreading kindness in mailing lists and other public fora, and submitting and reviewing pull requests! You are all magnificent.
 
-According to `git shortlog -sn --no-merges v2.11.4..v2.11.5`, 30 people contributed to this minor release:
-Jason Zaugg, Lukas Rytz, Michał Pociecha, A. P. Marki, Antoine Gourlay, Heather Miller, Adriaan Moors, Rex Kerr, Simon Ochsenreither, Gerard Basler, Denton Cockburn, Kenji Yoshida, Ye Xianjin, Guy Dickinson, Jean-Remi Desjardins, Alissa Rao, Lukasz Piepiora, Maxim Valyanskiy, Paolo Giarrusso, Philipp Haller, Rafał Krzewski, Eugene Vigdorchik, Rui Gonçalves, Erik Erlandson, Steve Gury, Teemu Lehtinen, Tim Harper, Dick Wall, Guillaume Martres, Grzegorz Kossakowski.
+According to `git shortlog -sn --no-merges v2.11.5..v2.11.6`, 25 people contributed to this minor release:
+Jason Zaugg, Adriaan Moors, Lukas Rytz, A. P. Marki, Denton Cockburn, Rex Kerr, mpociecha, Aleksandar Prokopec, Jan Bessai, Eugene Burmako, JustinPihony, Kornel Kielczewski, Krzysztof Romanowski, Eric Peters, Lyle Kopnicky, Mark Zitnik, Michael Pigg, Miles Sabin, BartekJanota, Simon Ochsenreither, Sébastien Doeraene, Viktor Klang, dickwall, jhegedus42, and Ikumi Shimizu. Thank you!

--- a/hand-written.md
+++ b/hand-written.md
@@ -1,26 +1,28 @@
-<!---
-NOTE: Our generator now strips triple-dash comments form the generated markdown.
-      These have been problematic for jekyll.
-Things to update:
-- replace 2.11.0-RCX-1 by previous version,
-- replace 2.11.0-RCX by actual version,
-- milestone=32 by actual milestone number
-- bug/PR counts
--->
-
-We are very pleased to announce the final release of Scala 2.11.0!
+We are very pleased to announce the release of Scala 2.11.1!
 
 * Get started with the [Hello Scala 2.11 template](https://typesafe.com/activator/template/hello-scala-2_11) in [Typesafe Activator](https://typesafe.com/platform/getstarted)
-* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.0.html)
-* Obtain it via [Maven Central](http://search.maven.org/?search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.0%22#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.0%22)
+* Download a distribution from [scala-lang.org](http://scala-lang.org/download/2.11.1.html)
+* Obtain it via [Maven Central](http://search.maven.org/?search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.1%22#search%7Cga%7C1%7Cg%3A%22org.scala-lang%22%20AND%20v%3A%222.11.1%22)
 
-There have been no code changes since RC4, just improvements to documentation and version bump to the most recent stable version of Akka actors. Here's the [difference between the release and RC4](https://github.com/scala/scala/compare/v2.11.0-RC4...v2.11.0).
+This release contains [an important fix](https://github.com/scala/scala/pull/3711) for serialization, which was broken in Scala 2.11.0 ([SI-8549](https://issues.scala-lang.org/browse/SI-8549)).
+The fix necessarily breaks serialization compatibility between 2.11.0 and 2.11.1 (this is separate from binary compatibility, which is maintained).
 
-Code that compiled on 2.10.x without deprecation warnings should compile on 2.11.x (we do not guarantee this for experimental APIs, such as reflection). If not, [please file a regression](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11311&labels=regression). We are working with the community to ensure availability of the core projects of the Scala 2.11.x eco-system, please see below for a list. This release is *not* binary compatible with the 2.10.x series, to allow us to keep improving the Scala standard library.
+Users of distributed systems that rely on serialization to exchange objects (such as akka) should upgrade to Scala 2.11.1 (and akka 2.3.3) immediately.
+We also strongly recommend that libraries that themselves declare classes with [@SerialVersionUID](http://www.scala-lang.org/api/2.11.0/index.html#scala.SerialVersionUID) annotations release a new version and ask their Scala 2.11 users to upgrade.
+
+We apologize for the breakage. We have included a new suite of tests that will ensure stability of serialization for the remainder of the 2.11.x series.
 
 <!--break-->
 
-The Scala 2.11.x series targets Java 6, with (evolving) experimental support for Java 8. In 2.11.0, Java 8 support is mostly limited to reading Java 8 bytecode and parsing Java 8 source. Stay tuned for more complete (experimental) Java 8 support.
+This release fixes [26 issues](https://issues.scala-lang.org/browse/SI-8549?jql=project%20%3D%20SI%20AND%20fixVersion%20%3D%20%22Scala%202.11.1%22%20AND%20resolution%20%3D%20fixed%20ORDER%20BY%20priority%20DESC). We reviewed and merged [51 pull requests](https://github.com/scala/scala/issues?milestone=34&state=closed).
+
+The next minor Scala 2.11 release will be available in at most 2 months, or sooner if prompted by a serious issue.
+
+### Upgrading
+Code that compiled on 2.10.x without deprecation warnings should compile on 2.11.x (we do not guarantee this for experimental APIs, such as reflection). If not, [please file a regression](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11311&labels=regression). We are working with the community to ensure availability of the core projects of the Scala 2.11.x eco-system, please see below for a list. This release is *not* binary compatible with the 2.10.x series, to allow us to keep improving the Scala standard library.
+
+### Required Java Version
+The Scala 2.11.x series targets Java 6, with (evolving) experimental support for Java 8. In 2.11.1, Java 8 support is mostly limited to reading Java 8 bytecode and parsing Java 8 source. Stay tuned for more complete (experimental) Java 8 support. The next major release, 2.12, will most likely target Java 8 by default.
 
 ### New features in the 2.11 series
 This release contains all of the bug fixes and improvements made in the 2.10 series, as well as:
@@ -32,7 +34,7 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * `List` has improved performance on `map`, `flatMap`, and `collect`.
   * See also Deprecation above: we have slated many classes and methods to become final, to clarify which classes are not meant to be subclassed and to facilitate future maintenance and performance improvements.
 * Modularization
-  * The core Scala standard library jar has shed 20% of its bytecode. The modules for xml, parsing, swing as well as the (unsupported) continuations plugin and library are available individually or via [scala-library-all](http://search.maven.org/#artifactdetails%7Corg.scala-lang%7Cscala-library-all%7C2.11.0%7Cpom). Note that this artifact has weaker binary compatibility guarantees than `scala-library` -- as explained above.
+  * The core Scala standard library jar has shed 20% of its bytecode. The modules for xml, parsing, swing as well as the (unsupported) continuations plugin and library are available individually or via [scala-library-all](http://search.maven.org/#artifactdetails%7Corg.scala-lang%7Cscala-library-all%7C2.11.1%7Cpom). Note that this artifact has weaker binary compatibility guarantees than `scala-library` -- as explained above.
   * The compiler has been modularized internally, to separate the presentation compiler, scaladoc and the REPL. We hope this will make it easier to contribute. In this release, all of these modules are still packaged in scala-compiler.jar. We plan to ship them in separate JARs in 2.12.x.
 * Reflection, macros and quasiquotes
   * Please see [this detailed changelog](http://docs.scala-lang.org/overviews/macros/changelog211.html) that lists all significant changes and provides advice on forward and backward compatibility.
@@ -43,12 +45,12 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * A new experimental way of compiling closures, implemented by [@JamesIry](https://github.com/JamesIry). With `-Ydelambdafy:method` anonymous functions are compiled faster, with a smaller bytecode footprint. This works by keeping the function body as a private (static, if no `this` reference is needed) method of the enclosing class, and at the last moment during compilation emitting a small anonymous class that `extends FunctionN` and delegates to it. This sets the scene for a smooth migration to Java 8-style lambdas (not yet implemented).
   * Branch elimination through constant analysis [#2214](https://github.com/scala/scala/pull/2214)
   * [Scala.js](http://www.scala-js.org/), a separate project, provides an experimental JavaScript back-end for Scala 2.11. Note that it is not part of the standard Scala distribution.
-  * Be more [Avian](http://oss.readytalk.com/avian/)- [friendly](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.0-M1%22%20and%20fixVersion%20%3C%3D%20%22Scala%202.11.0%22%20and%20resolution%20%3D%20fixed%20and%20text%20~%20%22avian%22).
+  * Be more [Avian](http://oss.readytalk.com/avian/)- [friendly](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.0-M1%22%20and%20fixVersion%20%3C%3D%20%22Scala%202.11.1%22%20and%20resolution%20%3D%20fixed%20and%20text%20~%20%22avian%22).
 * Compiler Performance
   * Incremental compilation has been improved significantly. To try it out, upgrade to sbt 0.13.2 and add `incOptions := incOptions.value.withNameHashing(true)` to your build! Other build tools are also supported. More info at [this sbt issue](https://github.com/sbt/sbt/issues/1010) -- that's where most of the work happened. More features are planned, e.g. [class-based tracking](https://github.com/sbt/sbt/issues/1104).
   * We've been optimizing the batch compiler's performance as well, and will continue to work on this during the 2.11.x cycle.
   * Improve performance of reflection [SI-6638](https://issues.scala-lang.org/browse/SI-6638)
-* The IDE received [numerous bug fixes and improvements!](https://issues.scala-lang.org/browse/SI-8085?jql=component%20%3D%20%22Presentation%20Compiler%22%20AND%20project%20%3D%20SI%20AND%20resolution%20%3D%20fixed%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.0-M1%22%20and%20fixVersion%20%3C%3D%20%20%22Scala%202.11.0%22%20ORDER%20BY%20updated%20DESC)
+* The IDE received [numerous bug fixes and improvements!](https://issues.scala-lang.org/browse/SI-8085?jql=component%20%3D%20%22Presentation%20Compiler%22%20AND%20project%20%3D%20SI%20AND%20resolution%20%3D%20fixed%20and%20fixVersion%20%3E%3D%20%22Scala%202.11.0-M1%22%20and%20fixVersion%20%3C%3D%20%20%22Scala%202.11.1%22%20ORDER%20BY%20updated%20DESC)
 * REPL
   * The bytecode decompiler command, :javap, now works with Java 7 [SI-4936](https://issues.scala-lang.org/browse/SI-4936) and has sprouted new options [SI-6894](https://issues.scala-lang.org/browse/SI-6894) (Thanks, [@som-snytt](https://github.com/som-snytt)!)
   * Added command :kind to help to tell ground types from type constructors. [#2340](https://github.com/scala/scala/pull/2340) (Thanks, [George Leontiev](https://github.com/folone) and [Eugene Yokota](https://github.com/eed3si9n)!)
@@ -61,11 +63,11 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * Scala 2.10 shipped with new implementations of the Pattern Matcher and the Bytecode Emitter. We have removed the old implementations.
   * Search and destroy mission for ~5000 chunks of dead code. [#1648](https://github.com/scala/scala/pull/1648/files)
 
-The Scala team and contributors [fixed 613 bugs](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20>%3D%20"Scala%202.11.0-M1"%20and%20fixVersion%20<%3D%20"Scala%202.11.0"%20and%20resolution%20%3D%20fixed) that are exclusive to Scala 2.11.0! We also backported as many as possible. With the release of 2.11, 2.10 backports will be dialed back.
+The Scala team and contributors [fixed 655 bugs](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20and%20fixVersion%20>%3D%20"Scala%202.11.0-M1"%20and%20fixVersion%20<%3D%20"Scala%202.11.1"%20and%20resolution%20%3D%20fixed) that are exclusive to Scala 2.11! We also backported as many as possible. With the release of 2.11, 2.10 backports will be dialed back.
 
 A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, participating in mailing lists and other public fora, and -- of course -- submitting and reviewing pull requests! You are all awesome.
 
-Concretely, according to `git log --no-merges --oneline master --not 2.10.x --format='%aN'  | sort | uniq -c | sort -rn`, 112 people contributed code, tests, and/or documentation to Scala 2.11.x: Paul Phillips, Jason Zaugg, Eugene Burmako, Adriaan Moors, Den Shabalin, Simon Ochsenreither, A. P. Marki, Miguel Garcia, James Iry, Iain McGinniss, Rex Kerr, Grzegorz Kossakowski, Vladimir Nikolaev, Eugene Vigdorchik, François Garillot, Mirco Dotta, Rüdiger Klaehn, Raphael Jolly, Kenji Yoshida, Paolo Giarrusso, Antoine Gourlay, Hubert Plociniczak, Aleksandar Prokopec, Simon Schaefer, Lex Spoon, Andrew Phillips, Sébastien Doeraene, Luc Bourlier, Josh Suereth, Jean-Remi Desjardins, Vojin Jovanovic, Vlad Ureche, Viktor Klang, Valerian, Prashant Sharma, Pavel Pavlov, Michael Thorpe, Jan Niehusmann, Heejong Lee, George Leontiev, Daniel C. Sobral, Christoffer Sawicki, yllan, rjfwhite, Volkan Yazıcı, Ruslan Shevchenko, Robin Green, Olivier Blanvillain, Lukas Rytz, James Ward, Iulian Dragos, Ilya Maykov, Eugene Yokota, Erik Osheim, Dan Hopkins, Chris Hodapp, Antonio Cunei, Andriy Polishchuk, Alexander Clare, 杨博, srinivasreddy, secwall, nermin, martijnhoekstra, kurnevsky, jinfu-leng, folone, Yaroslav Klymko, Xusen Yin, Trent Ogren, Tobias Schlatter, Thomas Geier, Stuart Golodetz, Stefan Zeiger, Scott Carey, Samy Dindane, Sagie Davidovich, Runar Bjarnason, Roland Kuhn, Roberto Tyley, Robert Nix, Robert Ladstätter, Rike-Benjamin Schuppner, Rajiv, Philipp Haller, Nada Amin, Mike Morearty, Michael Bayne, Mark Harrah, Luke Cycon, Lee Mighdoll, Konstantin Fedorov, Julio Santos, Julien Richard-Foy, Juha Heljoranta, Johannes Rudolph, Jiawei Li, Jentsch, Jason Swartz, James Roper, Havoc Pennington, Evgeny Kotelnikov, Dmitry Petrashko, Dmitry Bushev, David Hall, Daniel Darabos, Dan Rosen, Cody Allen, Carlo Dapor, Brian McKenna, Andrey Kutejko, Alden Torres.
+Concretely, according to `git log --no-merges --oneline 2.11.x --not 2.10.x --format='%aN'  | sort | uniq -c | sort -rn`, 115 people contributed code, tests, and/or documentation to Scala 2.11.x: Paul Phillips, Jason Zaugg, Eugene Burmako, Adriaan Moors, A. P. Marki, Simon Ochsenreither, Den Shabalin, Miguel Garcia, James Iry, Iain McGinniss, Grzegorz Kossakowski, Rex Kerr, François Garillot, Vladimir Nikolaev, Eugene Vigdorchik, Lukas Rytz, Mirco Dotta, Rüdiger Klaehn, Antoine Gourlay, Raphael Jolly, Simon Schaefer, Kenji Yoshida, Paolo Giarrusso, Luc Bourlier, Hubert Plociniczak, Aleksandar Prokopec, Vlad Ureche, Lex Spoon, Andrew Phillips, Sébastien Doeraene, Josh Suereth, Jean-Remi Desjardins, Vojin Jovanovic, Viktor Klang, Valerian, Prashant Sharma, Pavel Pavlov, Michael Thorpe, Jan Niehusmann, Iulian Dragos, Heejong Lee, George Leontiev, Daniel C. Sobral, Christoffer Sawicki, yllan, rjfwhite, Volkan Yazıcı, Ruslan Shevchenko, Robin Green, Roberto Tyley, Olivier Blanvillain, Mark Harrah, James Ward, Ilya Maykov, Eugene Yokota, Erik Osheim, Dan Hopkins, Chris Hodapp, Antonio Cunei, Andriy Polishchuk, Alexander Clare, 杨博, srinivasreddy, secwall, nermin, martijnhoekstra, kurnevsky, jinfu-leng, folone, Yaroslav Klymko, Xusen Yin, Trent Ogren, Tobias Schlatter, Thomas Geier, Stuart Golodetz, Stefan Zeiger, Scott Carey, Samy Dindane, Sagie Davidovich, Runar Bjarnason, Roland Kuhn, Robert Nix, Robert Ladstätter, Rike-Benjamin Schuppner, Rajiv, Philipp Haller, Nada Amin, Mike Morearty, Michael Bayne, Marcin Kubala, Luke Cycon, Lee Mighdoll, Konstantin Fedorov, Julio Santos, Julien Richard-Foy, Juha Heljoranta, Johannes Rudolph, Jiawei Li, Jentsch, Jason Swartz, James Roper, Heather Miller, Havoc Pennington, Guillaume Martres, Evgeny Kotelnikov, Dmitry Petrashko, Dmitry Bushev, David Hall, Daniel Darabos, Dan Rosen, Cody Allen, Carlo Dapor, Brian McKenna, Andrey Kutejko, Alden Torres.
 
 Thank you all very much.
 
@@ -74,13 +76,18 @@ If you find any errors or omissions in these relates notes, [please submit a PR]
 ### Reporting Bugs / Known Issues
 Please [file any bugs you encounter](https://issues.scala-lang.org/secure/CreateIssueDetails!init.jspa?pid=10005&issuetype=1&versions=11311). If you're unsure whether something is a bug, please contact the [scala-user](https://groups.google.com/forum/?fromgroups#!forum/scala-user) mailing list.
 
-Before reporting a bug, please have a look at these [known issues](https://issues.scala-lang.org/issues/?jql=project%20%3D%20SI%20AND%20fixVersion%20%21%3D%20%22Scala%202.11.0-RC3%22%20AND%20affectedVersion%20%3D%20%22Scala%202.11.0%22%20%20and%20resolution%20%3D%20unresolved%20ORDER%20BY%20priority%20DESC).
+Before reporting a bug, please have a look at these [known issues](https://issues.scala-lang.org/browse/SI-6267?jql=project%20%3D%20SI%20AND%20(fixVersion%20is%20empty%20or%20fixVersion%20%3E%20%22Scala%202.11.1%22)%20AND%20affectedVersion%20in%20(%22Scala%202.11.0%22%2C%20%22Scala%202.11.1%22)%20%20and%20resolution%20%3D%20unresolved%20ORDER%20BY%20priority%20DESC).
 
 ### Scala IDE for Eclipse
-The Scala IDE with this release built in is [available from this update site](http://download.scala-ide.org/sdk/helium/e38/scala211/stable/site/) for [Eclipse 4.2/4.3 (Juno/Kepler)](http://www.eclipse.org/downloads/packages/eclipse-ide-java-developers/keplersr2). Please have a look at the [getting started guide](http://scala-ide.org/docs/user/gettingstarted.html) for more info.
+The Scala IDE with this release built in will soon be available.
+<!-- 
+
+is [available from this update site](http://download.scala-ide.org/sdk/helium/e38/scala211/stable/site/) for [Eclipse 4.2/4.3 (Juno/Kepler)](http://www.eclipse.org/downloads/packages/eclipse-ide-java-developers/keplersr2). Please have a look at the [getting started guide](http://scala-ide.org/docs/user/gettingstarted.html) for more info.
+
+-->
 
 ### Available projects
-The following Scala projects have already been released against 2.11.0! We'd love to include yours in this list as soon as it's available -- please submit a PR to update [these release notes](https://github.com/scala/make-release-notes/blob/master/hand-written.md).
+The following Scala projects have already been released against 2.11! We'd love to include yours in this list as soon as it's available -- please submit a PR to update [these release notes](https://github.com/scala/make-release-notes/blob/master/hand-written.md).
 
     "org.scalacheck"                   %% "scalacheck"                % "1.11.3"
     "org.scalatest"                    %% "scalatest"                 % "2.1.3"
@@ -123,7 +130,6 @@ The following Scala projects have already been released against 2.11.0! We'd lov
     "org.scala-stm"                    %% "scala-stm"                 % "0.7"
     "org.parboiled"                    %% "parboiled-scala"           % "1.1.6"
     "io.spray"                         %% "spray-json"                % "1.2.6"
-    "org.scalamacros"                   % "paradise"                  % "2.0.0" cross CrossVersion.full
     "org.scala-libs"                   %% "scalajpa"                  % "1.5"
     "com.casualmiracles"               %% "treelog"                   % "1.2.3"
     "org.monifu"                       %% "monifu"                    % "0.6.1"
@@ -131,19 +137,14 @@ The following Scala projects have already been released against 2.11.0! We'd lov
     "com.clarifi"                      %% "f0"                        % "1.1.2"
     "org.scalaj"                       %% "scalaj-http"               % "0.3.15"
 
-The following projects were released against 2.11.0-RC4, with an 2.11 build hopefully following soon:
-
-    "org.scalafx"            %% "scalafx"            % "8.0.0-R4"
-    "org.scalafx"            %% "scalafx"            % "1.0.0-R8"
-
 ### Cross-building with sbt 0.13
 When cross-building between Scala versions, you often need to vary the versions of your dependencies. In particular, the new scala modules (such as scala-xml) are no longer included in scala-library, so you'll have to add an explicit dependency on it to use Scala's xml support.
 
 Here's how we recommend handling this in sbt 0.13. For the full build and Maven build, see [example](https://github.com/scala/scala-module-dependency-sample).
 
-    scalaVersion        := "2.11.0"
+    scalaVersion        := "2.11.1"
 
-    crossScalaVersions  := Seq("2.11.0", "2.10.3")
+    crossScalaVersions  := Seq("2.11.1", "2.10.3")
 
     // add scala-xml dependency when needed (for Scala 2.11 and newer)
     // this mechanism supports cross-version publishing
@@ -173,6 +174,7 @@ The following changes were made after a deprecation cycle (Thank you, [@soc](htt
 
 Finally, some notable improvements and bug fixes:
 
+* [SI-8549](https://issues.scala-lang.org/browse/SI-8549) Fix bad regression: no `serialVersionUID` field for classes annotated with [@SerialVersionUID](http://www.scala-lang.org/api/2.11.0/index.html#scala.SerialVersionUID). The Scala standard library itself was a victim of this bug. As such, collections serialized in 2.11.0 will not be able to be deserialized in 2.11.1. This regression occurred in a failed [attempt](https://github.com/scala/scala/pull/1673) to fix a related bug in 2.10.x, [SI-6988](https://issues.scala-lang.org/browse/SI-6988), whereby classes annotated with non literal UIDS, e.g. `0L - 123L`, had no field generated. 
 * [SI-7296](https://issues.scala-lang.org/browse/SI-7296) Case classes with > 22 parameters are now allowed.
 * [SI-3346](https://issues.scala-lang.org/browse/SI-3346) Implicit arguments of implicit conversions now guide type inference.
 * [SI-6240](https://issues.scala-lang.org/browse/SI-6240) Thread safety of reflection API.
@@ -236,7 +238,7 @@ Just like the 2.10.x series, we guarantee forwards and backwards compatibility o
 
 Note that we will only enforce *backwards* binary compatibility for the new modules (artifacts under the groupId `org.scala-lang.modules`). As they are opt-in, it's less of a burden to require having the latest version on the classpath. (Without forward compatibility, the latest version of the artifact must be on the run-time classpath to avoid linkage errors.)
 
-Finally, Scala 2.11.0 introduces `scala-library-all` to aggregate the modules that constitute a Scala release. Note that this means it does not provide forward binary compatibility, whereas the core `scala-library` artifact does. We consider the versions of the modules that `"scala-library-all" % "2.11.x"` depends on to be the canonical ones, that are part of the official Scala distribution. (The distribution itself is defined by the new `scala-dist` maven artifact.)
+Finally, Scala 2.11 introduces `scala-library-all` to aggregate the modules that constitute a Scala release. Note that this means it does not provide forward binary compatibility, whereas the core `scala-library` artifact does. We consider the versions of the modules that `"scala-library-all" % "2.11.x"` depends on to be the canonical ones, that are part of the official Scala distribution. (The distribution itself is defined by the new `scala-dist` maven artifact.)
 
 ### License clarification
 Scala is now distributed under the standard 3-clause BSD license. Originally, the same 3-clause BSD license was adopted, but slightly reworded over the years, and the "Scala License" was born. We're now back to the standard formulation to avoid confusion.

--- a/hand-written.md
+++ b/hand-written.md
@@ -20,7 +20,7 @@ The next minor Scala 2.11 release will be available in 2 months, or sooner if pr
 
 A large number of Scala projects have been released against Scala 2.11. Please refer to the list of [libraries and frameworks available for Scala 2.11](https://github.com/scala/make-release-notes/blob/2.11.x/projects-2.11.md).
 
-A release of the Scala IDE that includes Scala 2.11.2 is available [on their download site](http://scala-ide.org/download/sdk.html).
+A release of the Scala IDE that includes Scala 2.11.2 will be available shortly [on their download site](http://scala-ide.org/download/sdk.html).
 
 ### Release Notes for the Scala 2.11 Series
 

--- a/hand-written.md
+++ b/hand-written.md
@@ -8,7 +8,7 @@ This release contains [an important fix](https://github.com/scala/scala/pull/371
 The fix necessarily breaks serialization compatibility between 2.11.0 and 2.11.1 (this is separate from binary compatibility, which is maintained).
 
 Users of distributed systems that rely on serialization to exchange objects (such as akka) should upgrade to Scala 2.11.1 (and akka 2.3.3) immediately.
-We also strongly recommend that libraries that themselves declare classes with [@SerialVersionUID](http://www.scala-lang.org/api/2.11.0/index.html#scala.SerialVersionUID) annotations release a new version and ask their Scala 2.11 users to upgrade.
+We also strongly recommend that libraries that themselves declare classes with [@SerialVersionUID](http://www.scala-lang.org/api/2.11.1/index.html#scala.SerialVersionUID) annotations release a new version and ask their Scala 2.11 users to upgrade.
 
 We apologize for the breakage. We have included a new suite of tests that will ensure stability of serialization for the remainder of the 2.11.x series.
 
@@ -177,7 +177,7 @@ The following changes were made after a deprecation cycle (Thank you, [@soc](htt
 
 Finally, some notable improvements and bug fixes:
 
-* [SI-8549](https://issues.scala-lang.org/browse/SI-8549) Fix bad regression: no `serialVersionUID` field for classes annotated with [@SerialVersionUID](http://www.scala-lang.org/api/2.11.0/index.html#scala.SerialVersionUID). The Scala standard library itself was a victim of this bug. As such, collections serialized in 2.11.0 will not be able to be deserialized in 2.11.1. This regression occurred in a failed [attempt](https://github.com/scala/scala/pull/1673) to fix a related bug in 2.10.x, [SI-6988](https://issues.scala-lang.org/browse/SI-6988), whereby classes annotated with non literal UIDS, e.g. `0L - 123L`, had no field generated. 
+* [SI-8549](https://issues.scala-lang.org/browse/SI-8549) Fix bad regression: no `serialVersionUID` field for classes annotated with [@SerialVersionUID](http://www.scala-lang.org/api/2.11.1/index.html#scala.SerialVersionUID). The Scala standard library itself was a victim of this bug. As such, collections serialized in 2.11.0 will not be able to be deserialized in 2.11.1. This regression occurred in a failed [attempt](https://github.com/scala/scala/pull/1673) to fix a related bug in 2.10.x, [SI-6988](https://issues.scala-lang.org/browse/SI-6988), whereby classes annotated with non literal UIDS, e.g. `0L - 123L`, had no field generated. 
 * [SI-7296](https://issues.scala-lang.org/browse/SI-7296) Case classes with > 22 parameters are now allowed.
 * [SI-3346](https://issues.scala-lang.org/browse/SI-3346) Implicit arguments of implicit conversions now guide type inference.
 * [SI-6240](https://issues.scala-lang.org/browse/SI-6240) Thread safety of reflection API.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.1
+sbt.version=0.13.7

--- a/projects-2.11.md
+++ b/projects-2.11.md
@@ -9,7 +9,7 @@ We'd love to include your release in this list as soon as it's available -- plea
     "org.scalacheck"                   %% "scalacheck"                % "1.11.4"
     "org.scalatest"                    %% "scalatest"                 % "2.1.7"
     "org.scalautils"                   %% "scalautils"                % "2.1.3"
-    "com.typesafe.akka"                %% "akka-actor"                % "2.3.2"
+    "com.typesafe.akka"                %% "akka-actor"                % "2.3.4"
     "com.typesafe.scala-logging"       %% "scala-logging-slf4j"       % "2.1.2"
     "org.scala-lang.modules"           %% "scala-async"               % "0.9.1"
     "org.scalikejdbc"                  %% "scalikejdbc-interpolation" % "2.0.0-beta1"

--- a/projects-2.11.md
+++ b/projects-2.11.md
@@ -1,0 +1,60 @@
+### Available Projects for Scala 2.11
+
+The following Scala projects have been released against Scala 2.11. See also:
+* [@jrudolph](https://github.com/jrudolph)'s list of [library versions for Scala 2.11](https://gist.github.com/jrudolph/7a323f5e2820d8479b18).
+* The "[Awesome Scala](https://github.com/lauris/awesome-scala)" list of libraries and frameworks, maintained by [@lauris](https://github.com/lauris).
+
+We'd love to include your release in this list as soon as it's available -- please submit a PR to update [this list](https://github.com/scala/make-release-notes/blob/2.11.x/projects-2.11.md).
+
+    "org.scalacheck"                   %% "scalacheck"                % "1.11.4"
+    "org.scalatest"                    %% "scalatest"                 % "2.1.7"
+    "org.scalautils"                   %% "scalautils"                % "2.1.3"
+    "com.typesafe.akka"                %% "akka-actor"                % "2.3.2"
+    "com.typesafe.scala-logging"       %% "scala-logging-slf4j"       % "2.1.2"
+    "org.scala-lang.modules"           %% "scala-async"               % "0.9.1"
+    "org.scalikejdbc"                  %% "scalikejdbc-interpolation" % "2.0.0-beta1"
+    "com.softwaremill.scalamacrodebug" %% "macros"                    % "0.4"
+    "com.softwaremill.macwire"         %% "macros"                    % "0.6"
+    "com.chuusai"                      %% "shapeless"                 % "1.2.4"
+    "com.chuusai"                      %% "shapeless"                 % "2.0.0"
+    "org.nalloc"                       %% "optional"                  % "0.1.0"
+    "org.scalaz"                       %% "scalaz-core"               % "7.0.6"
+    "com.assembla.scala-incubator"     %% "graph-core"                % "1.8.1"
+    "com.nocandysw"                    %% "platform-executing"        % "0.5.0"
+    "com.qifun"                        %% "stateless-future"          % "0.1.1"
+    "com.github.scopt"                 %% "scopt"                     % "3.2.0"
+    "com.dongxiguo"                    %% "commons-continuations"     % "0.2.2"
+    "com.dongxiguo"                    %% "memcontinuationed"         % "0.3.2"
+    "com.dongxiguo"                    %% "fastring"                  % "0.2.4"
+    "com.dongxiguo"                    %% "zero-log"                  % "0.3.5"
+    "com.github.seratch"               %% "ltsv4s"                    % "1.0.0"
+    "com.googlecode.kiama"             %% "kiama"                     % "1.5.3"
+    "org.scalamock"                    %% "scalamock-scalatest-support" % "3.0.1"
+    "org.scalamock"                    %% "scalamock-specs2-support"  % "3.0.1"
+    "com.github.nscala-time"           %% "nscala-time"               % "1.0.0"
+    "com.github.xuwei-k"               %% "applybuilder70"            % "0.1.2"
+    "com.github.xuwei-k"               %% "nobox"                     % "0.1.9"
+    "org.typelevel"                    %% "scodec-bits"               % "1.0.0"
+    "org.typelevel"                    %% "scodec-core"               % "1.0.0"
+    "com.sksamuel.scrimage"            %% "scrimage"                  % "1.3.20"
+    "net.databinder"                   %% "dispatch-http"             % "0.8.10"
+    "net.databinder"                   %% "unfiltered"                % "0.8.0"
+    "net.databinder"                   %% "unfiltered"                % "0.7.1"
+    "io.argonaut"                      %% "argonaut"                  % "6.0.4"
+    "org.specs2"                       %% "specs2"                    % "2.3.12"
+    "com.propensive"                   %% "rapture-core"              % "0.9.0"
+    "com.propensive"                   %% "rapture-json"              % "0.9.1"
+    "com.propensive"                   %% "rapture-io"                % "0.9.1"
+    "org.scala-stm"                    %% "scala-stm"                 % "0.7"
+    "org.parboiled"                    %% "parboiled-scala"           % "1.1.6"
+    "io.spray"                         %% "spray-json"                % "1.2.6"
+    "org.scala-libs"                   %% "scalajpa"                  % "1.5"
+    "com.casualmiracles"               %% "treelog"                   % "1.2.3"
+    "org.monifu"                       %% "monifu"                    % "0.6.1"
+    "org.mongodb"                      %% "casbah"                    % "2.7.1"
+    "com.clarifi"                      %% "f0"                        % "1.1.2"
+    "org.scalaj"                       %% "scalaj-http"               % "0.3.15"
+
+The following libraries are specific to the 2.11.x minor release you're using. If you depend on them, you should also cross-version fully!
+
+    "org.scalamacros"                   % "paradise"                  % "2.0.0" cross CrossVersion.full

--- a/projects-2.12.md
+++ b/projects-2.12.md
@@ -1,0 +1,9 @@
+### Available Projects for Scala 2.12
+
+This list gives an overview of projects that have been released against Scala 2.12.
+
+Please [submit a pull request](https://github.com/scala/make-release-notes/edit/2.12.x/projects-2.12.md) to update this list!
+
+#### Scala 2.12.0-M1
+
+    "org.scalacheck"                   %% "scalacheck"                % "1.11.6"

--- a/src/main/scala/MakeDownloadPage.scala
+++ b/src/main/scala/MakeDownloadPage.scala
@@ -55,14 +55,14 @@ class MakeDownloadPage(version: String, releaseDate: Date = new Date()) {
 
   def resources: String = Await.result(
     Future.sequence(Seq(
-        resourceArchive(unixClass,       "scala",                "tgz", "Max OS X, Unix, Cygwin"   ),
-        resourceArchive(windowsClass,    "scala",                "msi", "Windows (msi installer)"  ),
-        resourceArchive(defaultClass,    "scala",                "zip", "Windows"                  ),
-        resourceArchive(defaultClass,    "scala",                "deb", "Debian"                   ),
-        resourceArchive(defaultClass,    "scala",                "rpm", "RPM package"              ),
-        resourceArchive(defaultClass,    "scala-docs",           "txz", "API docs"                 ),
-        resourceArchive(defaultClass,    "scala-docs",           "zip", "API docs"                 ),
-        resource       (defaultClass,    s"scala-sources-$version.zip", "sources", ghSourceUrl     )
+        resourceArchive(unixClass,       "scala",                "tgz",    "Max OS X, Unix, Cygwin"   ),
+        resourceArchive(windowsClass,    "scala",                "msi",    "Windows (msi installer)"  ),
+        resourceArchive(defaultClass,    "scala",                "zip",    "Windows"                  ),
+        resourceArchive(defaultClass,    "scala",                "deb",    "Debian"                   ),
+        resourceArchive(defaultClass,    "scala",                "rpm",    "RPM package"              ),
+        resourceArchive(defaultClass,    "scala-docs",           "txz",    "API docs"                 ),
+        resourceArchive(defaultClass,    "scala-docs",           "zip",    "API docs"                 ),
+        resource       (defaultClass,    s"scala-sources-$version.tar.gz", "Sources", ghSourceUrl     )
       )).map(_.mkString(",\n  ")), 30 seconds)
 
   // note: first and last lines must be exactly "---"

--- a/src/main/scala/MakeDownloadPage.scala
+++ b/src/main/scala/MakeDownloadPage.scala
@@ -16,7 +16,7 @@ class MakeDownloadPage(version: String, releaseDate: Date = new Date()) {
   // get size of `url` without actually downloading it
   def humanSize(url: String): Future[String] = future {
     import scala.sys.process._
-    println(url)
+    println("## fetching size of "+ url)
     scala.util.Try {
       val responseHeader = Process(s"curl -m 5 --silent -D - -X HEAD $url").lines
       val contentLength = responseHeader.find(_.startsWith("Content-Length"))
@@ -30,7 +30,7 @@ class MakeDownloadPage(version: String, releaseDate: Date = new Date()) {
       case Some((status, humanSize)) if status.contains("200 OK") || status.contains("302 Found") =>
         humanSize
       case _ =>
-        println(s"warning: could not fetch $url")
+        println(s"## warning: could not fetch $url")
         ""
     }
   }

--- a/src/main/scala/MakeReleaseNotes.scala
+++ b/src/main/scala/MakeReleaseNotes.scala
@@ -22,9 +22,9 @@ object MakeReleaseNotes {
 
     if (ext == "md") {
       println(s"cp $fileName ../scala-lang/news/_posts/")
-      println(s"don't forget to update ../scala-lang/download/index.md, ../scala-lang/documentation/api.md, ../scala-lang/documentation/_config.yml")
+      println(s"# don't forget to\n${scala.util.Properties.envOrElse("EDITOR", "mate")} ../scala-lang/download/index.md ../scala-lang/documentation/api.md ../scala-lang/_config.yml")
+      println("# and, to prepare and sanity check your scala-lang PR:")
       println(s"maruku --html $fileName")
-      println("# to prepare and sanity check your scala-lang PR")
     }
   }
 
@@ -104,12 +104,7 @@ layout: news
 post-type: announcement
 title: "Scala ${currentTag drop 1} is now available!"
 ---
-${rawHandWrittenNotes()}
-
-${renderCommitterList}
-${renderFixedIssues}
-${renderCommitList}
-      """
+${rawHandWrittenNotes()}"""
     }
 
   }

--- a/src/main/scala/MakeReleaseNotes.scala
+++ b/src/main/scala/MakeReleaseNotes.scala
@@ -8,7 +8,7 @@ object MakeReleaseNotes {
   def genPR(prevVersion: String, version: String, release: String, gitDir: String = s"${sys.env("HOME")}/git/scala") = {
     val date = new java.util.Date(release)
     new MakeDownloadPage(version, date).write()
-    MakeReleaseNotes(new java.io.File(gitDir), s"v$prevVersion", s"v$version", MarkDown, date)
+    MakeReleaseNotes(new java.io.File(gitDir), version, s"v$prevVersion", s"v$version", MarkDown, date)
   }
 
   def write(page: String, version: String, releaseDate: Date, ext: String) = {
@@ -28,15 +28,15 @@ object MakeReleaseNotes {
     }
   }
 
-  def apply(scalaDir: String, previousTag: String, currentTag: String, releaseDate: Date) {
-    Seq(Html, MarkDown).foreach(fmt => apply(new java.io.File(scalaDir), previousTag, currentTag, fmt, releaseDate))
+  def apply(scalaDir: String, version: String, previousTag: String, currentTag: String, releaseDate: Date) {
+    Seq(Html, MarkDown).foreach(fmt => apply(new java.io.File(scalaDir), version, previousTag, currentTag, fmt, releaseDate))
   }
-  def apply(scalaDir: java.io.File, previousTag: String, currentTag: String, targetLanguage: TargetLanguage = MarkDown, releaseDate: Date = new Date()): Unit = {
+  def apply(scalaDir: java.io.File, version: String, previousTag: String, currentTag: String, targetLanguage: TargetLanguage = MarkDown, releaseDate: Date = new Date()): Unit = {
     val out = targetLanguage match {
       case Html => new java.io.File("release-notes.html")
       case MarkDown => new java.io.File(s"release-notes-${currentTag}.md")
     }
-    val notes = makeReleaseNotes(scalaDir, previousTag, currentTag)(targetLanguage)
+    val notes = makeReleaseNotes(scalaDir, version, previousTag, currentTag)(targetLanguage)
     write(notes, currentTag.dropWhile(_ == 'v'), releaseDate, targetLanguage.ext)
   }
 
@@ -62,7 +62,7 @@ object MakeReleaseNotes {
   private def stripTripleDashedHtmlComments(s: String): String =
     s.replaceAll("""(?ims)<!---.*?-->""", "")
 
-  private def makeReleaseNotes(scalaDir: java.io.File, previousTag: String, currentTag: String)(implicit targetLanguage: TargetLanguage): String = {
+  private def makeReleaseNotes(scalaDir: java.io.File, version: String, previousTag: String, currentTag: String)(implicit targetLanguage: TargetLanguage): String = {
     def rawHandWrittenNotes(file: java.io.File = new java.io.File(s"hand-written.md")): String = {
       val lines: List[String] = if (file.exists) {
         val src = Source.fromFile(file)
@@ -102,6 +102,7 @@ object MakeReleaseNotes {
       case MarkDown => s"""---
 layout: news
 post-type: announcement
+permalink: /news/$version
 title: "Scala ${currentTag drop 1} is now available!"
 ---
 ${rawHandWrittenNotes()}"""


### PR DESCRIPTION
there were some changes in the 2.11.x branch that can be ported to 2.12.x. i cherry-picked them individually and then merged 2.11.x with `-s ours`:

```
lucmac:make-release-notes luc$ git cherry-pick 3eb979073107c5d0d8348487c5d36404165d2fc7
[2.12.0-M1 874396e] file extesion and artifact name for soruces
 Date: Wed Jul 23 16:38:09 2014 +0200
 1 file changed, 8 insertions(+), 8 deletions(-)

lucmac:make-release-notes luc$ git cherry-pick 2f7600caf6d8b9085314a9e616078bca6cb8ca6a
[2.12.0-M1 dfaed89] small tweaks to generator
 Author: Adriaan Moors <adriaan.moors@typesafe.com>
 Date: Wed Jan 14 10:37:32 2015 -0800
 4 files changed, 8 insertions(+), 13 deletions(-)

lucmac:make-release-notes luc$ git cherry-pick 4feae346746fa2aead806656e8d2547ed6ca7fdb
[2.12.0-M1 e366bfb] add news permalink
 Author: Adriaan Moors <adriaan.moors@typesafe.com>
 Date: Wed Jan 14 10:53:30 2015 -0800
 1 file changed, 7 insertions(+), 6 deletions(-)

lucmac:make-release-notes luc$ git merge -s ours 2.11.x
Merge made by the 'ours' strategy.

* f2ac666 - (HEAD -> 2.12.x, origin/2.12.x, 2.12.0-M1) Release notes for Scala 2.12.0-M1 (3 minutes ago) <Lukas Rytz>
*   84eabbf - Merge branch '2.11.x' into 2.12.0-M1 (3 minutes ago) <Lukas Rytz>
|\  
| *   d0fa856 - (upstream/2.11.x, 2.11.x) Merge pull request #137 from adriaanm/2.11.6 (9 weeks ago) <Adriaan Moors>
      [...]
| | * 4feae34 - add news permalink (4 months ago) <Adriaan Moors>
      [...]
| | * 2f7600c - small tweaks to generator (4 months ago) <Adriaan Moors>
      [...]
| | * 3eb9790 - file extesion and artifact name for soruces (10 months ago) <Lukas Rytz>
      [...]
* | e366bfb - add news permalink (3 minutes ago) <Adriaan Moors>
* | dfaed89 - small tweaks to generator (3 minutes ago) <Adriaan Moors>
* | 874396e - file extesion and artifact name for soruces (4 minutes ago) <Lukas Rytz>
* | 04b9f0f - (upstream/2.12.x) Started release notes for 2.12.0 (12 months ago) <Lukas Rytz>
|/  
* d81cfc2 - Manual rebase of #124 and #125 (12 months ago) <Adriaan Moors>
```

After this, one commit adds the release notes for 2.12.0-M1.
-  https://github.com/lrytz/make-release-notes/blob/2.12.x/hand-written.md
- https://github.com/lrytz/make-release-notes/blob/2.12.x/projects-2.12.md
