### PR TITLE
update scala-java8-compat from 0.5.0 to 0.7.0

### DIFF
--- a/experimental-backend.md
+++ b/experimental-backend.md
@@ -48,7 +48,7 @@ The Scala 2.11.7 compiler emits lambdas in Java 8 style (using `invokedynamic` a
 
 In an SBT project, this can be achieved using the following settings:
 
-    libraryDependencies += "org.scala-lang.modules" %% "scala-java8-compat" % "0.5.0"
+    libraryDependencies += "org.scala-lang.modules" %% "scala-java8-compat" % "0.7.0"
     
     scalacOptions ++= List("-Ybackend:GenBCode", "-Ydelambdafy:method", "-target:jvm-1.8")
 


### PR DESCRIPTION
This is just an update for the page that explains how to add scala-java8-compat for use with the experimental backend, to bump the version to the current latest (0.7.0).
