### PR TITLE
Add ScalikeJDBC on Scala 2.12.0-M3

### DIFF
--- a/projects-2.12.md
+++ b/projects-2.12.md
@@ -21,6 +21,7 @@ Other libraries, add in Sbt using `libraryDependencies += ...`
     "org.scalactic"                    %% "scalactic"                 % "2.2.5-M3"
     "org.scodec"                       %% "scodec-bits"               % "1.0.10"
     "com.chuusai"                      %% "shapeless"                 % "2.2.5"
+    "org.scalikejdbc"                  %% "scalikejdbc"               % "2.3.5"
 
 Sbt plugins, add using `addSbtPlugin`
 


### PR DESCRIPTION
Please add ScalikeJDBC library to the 2.12.0-M3 list.
- http://scalikejdbc.org/
- http://search.maven.org/#artifactdetails%7Corg.scalikejdbc%7Cscalikejdbc_2.12.0-M3%7C2.3.5%7Cjar
