### PR TITLE
Add Akka (actor) to 2.12 built libs

### DIFF
--- a/projects-2.12.md
+++ b/projects-2.12.md
@@ -32,6 +32,7 @@ Other libraries, add in sbt using `libraryDependencies += ...`
     "org.scodec"                       %% "scodec-bits"               % "1.0.12"
     "org.scodec"                       %% "scodec-bits"               % "1.1.0"
     "com.github.scopt"                 %% "scopt"                     % "3.4.0"
+    "com.typesafe.akka"                %% "akka-actor"                % "2.4.4"
 
 Compiler plugins, add in sbt using `addCompilerPlugin(...)`:
     


### PR DESCRIPTION
We've been building for each M release of 12, including just Actor in the list but most modules are ready.
