### PR TITLE
Add Enumeratum lib to 2.12.0-RC1 list of libs

### DIFF
--- a/projects-2.12.md
+++ b/projects-2.12.md
@@ -41,6 +41,7 @@ Other libraries, add in sbt using `libraryDependencies += ...`
     "com.typesafe.akka"                %% "akka-actor"                % "2.4.10"
     "com.typesafe.akka"                %% "akka-stream"               % "2.4.10"
     "com.typesafe.akka"                %% "akka-http-core"            % "2.4.10"
+    "com.beachape"                     %% "enumeratum"                % "1.4.14"
 
 Note that [Shapeless](https://github.com/milessabin/shapeless) will not be
 published for 2.12.0-RC1; see [#5395](https://github.com/scala/scala/pull/5395).


### PR DESCRIPTION
Macro and core have been tested and published for 2.12.0-RC1; integration libs waiting on libs being integrated with to publish their artefacts.
