### PR TITLE
tout new Scaladoc in 2.12 notes

### DIFF
--- a/hand-written.md
+++ b/hand-written.md
@@ -120,6 +120,14 @@ This [blog post series](https://github.com/viktorklang/blog)
 by Viktor Klang explores the diverse improvements made to
 `scala.concurrent.Future` for 2.12.
 
+#### Scaladoc look-and-feel overhauled
+
+Scaladoc's output is now more attractive, more modern, and easier
+to use.
+
+Thanks, [Felix Mulder](https://github.com/felixmulder), for leading
+this effort.
+
 #### Scaladoc now supports doc comments in Java sources
 
 Thanks, [Jakob Odersky](https://github.com/jodersky), for this fix to [SI-4826](https://issues.scala-lang.org/browse/SI-4826).


### PR DESCRIPTION
@felixmulder @VladUreche would you like to supply some short
additional text here highlighting specific improvements?

we want to keep the release notes short overall, so the key word here is
"short". if you want more space to write something longer, that could
be a blog post on scala-lang.org that we would link to from these
notes.
