### PR TITLE
Add scopt

### DIFF
--- a/projects-2.12.md
+++ b/projects-2.12.md
@@ -43,6 +43,7 @@ Other libraries, add in sbt using `libraryDependencies += ...`
     "com.typesafe.akka"                %% "akka-http-core"            % "2.4.10"
     "com.beachape"                     %% "enumeratum"                % "1.4.14"
     "com.typesafe.scala-logging"       %% "scala-logging"             % "3.5.0"
+    "com.github.scopt"                 %% "scopt"                     % "3.5.0"
 
 Note that [Shapeless](https://github.com/milessabin/shapeless) will not be
 published for 2.12.0-RC1; see [#5395](https://github.com/scala/scala/pull/5395).


### PR DESCRIPTION
Scopt 3.5.0 for 2.12.0-RC1 is on its way to Maven Central https://oss.sonatype.org/content/repositories/public/com/github/scopt/scopt_2.12.0-RC1/3.5.0/
