### PR TITLE
old URL for GitHub source downloads is now a redirect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 jdk: oraclejdk8
 script:
 - git clone -b 2.12.x https://github.com/scala/scala
-- sbt -Dfile.encoding=UTF-8 "runMain MakeReleaseNotes 2.11.8 2.12.0 2345/06/07 `pwd`/scala"
+- sbt -Dfile.encoding=UTF-8 "runMain MakeReleaseNotes 2.12.0 2.12.1 2345/06/07 `pwd`/scala"
 cache:
   directories:
   - $HOME/.ivy2


### PR DESCRIPTION
so adapt to that. in a clunky way.