### PR TITLE
Add Airframe (DI library for Scala) 0.9 Scala 2.12

### DIFF
--- a/projects-2.12.md
+++ b/projects-2.12.md
@@ -114,6 +114,7 @@ Add in sbt using `libraryDependencies += ...`:
     "org.typelevel"                    %% "discipline"                % "0.7.2"
     "org.typelevel"                    %% "macro-compat"              % "1.1.1"
     "org.wvlet"                        %% "wvlet-log"                 % "1.1"
+    "org.wvlet"                        %% "airframe"                  % "0.9"
     "pt.tecnico.dsi"                   %% "akka-kadmin"               % "0.5.0"
     "pt.tecnico.dsi"                   %% "akka-ldap"                 % "0.4.2"
     "pt.tecnico.dsi"                   %% "akkastrator"               % "0.8.0"


### PR DESCRIPTION
Airframe is a DI framework for Scala https://github.com/wvlet/airframe, and it now supports Scala 2.12:
https://oss.sonatype.org/content/repositories/releases/org/wvlet/airframe_2.12/