### PR TITLE
Use HTTPS in fullUrl by default for resources

### DIFF
--- a/src/main/scala/MakeDownloadPage.scala
+++ b/src/main/scala/MakeDownloadPage.scala
@@ -37,7 +37,7 @@ class MakeDownloadPage(version: String, releaseDate: Date = new Date()) {
 
   def resourceArchive(cls: String, name: String, ext: String, desc: String): Future[String] = {
     val fileName = s"$name-$version.$ext"
-    val fullUrl = s"http://downloads.lightbend.com/scala/$version/$fileName"
+    val fullUrl = s"https://downloads.lightbend.com/scala/$version/$fileName"
     resource(cls, fileName, desc, fullUrl, fullUrl)
   }
 


### PR DESCRIPTION
Since no redirect or HSTS is in place, these downloads are
vulnerable to being MitM'd. This commit changes all future
links to use "HTTPS" in the protocol part instead of "HTTP".

Related: scala/scala-lang#627