### PR TITLE
don't use old-fashioned Java version numbering

### DIFF
--- a/src/main/scala/MakeDownloadPage.scala
+++ b/src/main/scala/MakeDownloadPage.scala
@@ -75,7 +75,7 @@ release_version: $version
 release_date: "${format("MMMM dd, yyyy")}"
 show_resources: "true"
 permalink: /download/$version.html
-requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 6 or later, available <a href='http://www.java.com/'>here</a>."
 resources: [
   $resources
 ]


### PR DESCRIPTION
this has been bugging me for a while. if merged, I'll merge
it forward for 2.12.x and 2.13.x (and change it to "Java 8")