### PR TITLE
add scalaz

### DIFF
--- a/projects-2.13.md
+++ b/projects-2.13.md
@@ -36,11 +36,7 @@ Add in sbt using `libraryDependencies += ... % "test"`:
 
 Add in sbt using `libraryDependencies += ...`:
 
-(None yet! Add yours?)
-
-<!--
-    "org.scalaz"                       %% "scalaz-core"               % "7.2.7"
--->
+    "org.scalaz"                       %% "scalaz-core"               % "7.2.11"
 
 ### Compiler plugins
 


### PR DESCRIPTION
published only some jvm modules; `core`, `effect`, `concurrent`, `iteratee` (without scalacheck-bindings, scala-js, scala-native)

- https://oss.sonatype.org/content/repositories/releases/org/scalaz/scalaz-core_2.13.0-M1/
- https://oss.sonatype.org/content/repositories/releases/org/scalaz/scalaz-concurrent_2.13.0-M1/
- https://oss.sonatype.org/content/repositories/releases/org/scalaz/scalaz-effect_2.13.0-M1/
- https://oss.sonatype.org/content/repositories/releases/org/scalaz/scalaz-iteratee_2.13.0-M1/