### PR TITLE
Airframe now supports Scala 2.13.0-M5

### DIFF
--- a/projects-2.13.md
+++ b/projects-2.13.md
@@ -56,6 +56,7 @@ Add in sbt using `libraryDependencies += ...`:
     "com.github.mpilquist"             %% "simulacrum"                % "0.14.0"
     "org.scalatra.scalate"             %% "scalate-core"              % "1.9.1-RC1"
     "com.typesafe.scala-logging"       %% "scala-logging"             % "3.9.0"
+    "org.wvlet.airframe"               %% "airframe"                  % "0.72"
 
 ### Compiler plugins
 


### PR DESCRIPTION
Airframe, lightweight building blocks for Scala, now supports Scala 2.13.0-M5 https://wvlet.org/airframe/docs/release-notes.html#072