### PR TITLE
Remove chill blocking spark for scala 2.13

### DIFF
--- a/projects-2.13.md
+++ b/projects-2.13.md
@@ -20,7 +20,6 @@ You can subscribe to the linked tickets to find out when a library you want beco
   * lift-json and some other modules are available; others are still pending
 * [scala-continuations](https://github.com/scala/scala-continuations/issues/37)
 * [spark](https://issues.apache.org/jira/browse/SPARK-25075)
-  * blocked by chill
 * [RosHTTP](https://github.com/hmil/RosHTTP/pull/88)
 * [play-iteratees](https://github.com/playframework/play-iteratees/issues/16)
 * [scalajpa](https://github.com/dchenbecker/scalajpa/issues/10)


### PR DESCRIPTION
Chill is no longer a blocker for spark:
https://issues.apache.org/jira/browse/SPARK-29290